### PR TITLE
docs: 统一 Session 对比与覆盖度口径 (#14)

### DIFF
--- a/docs/实施计划.md
+++ b/docs/实施计划.md
@@ -2345,25 +2345,26 @@ _build/prod/rel/gong/bin/gong stop
 
 ### 与 Pi 的对比
 
-| 功能 | Pi (TypeScript / AgentSession) | Gong (Elixir / Session) |
-|------|----------------------------------|-------------------------|
-| 进程模型 | 单线程 EventEmitter | GenServer |
-| 状态管理 | 类属性 | State struct |
-| 事件订阅 | `subscribe(listener)` | `subscribe(pid, listener)` |
-| 消息队列 | 数组 | List |
-| 前端无关 | ✅ 是 | ✅ 是 |
-| 重试错误判断 | `_isRetryableError()`（排除 context overflow，正则匹配可重试错误） | `Gong.Retry.classify_error/1` + `should_retry?/2` |
-| 最后助手消息定位 | `_findLastAssistantMessage()` 反向遍历消息 | 反向遍历历史；会话侧约束为“跳过 aborted 空消息” |
-| 会话恢复模型/思考级别 | 从 session entries 恢复 model + thinking level | 部分对齐：已定义初始状态持久化，完整恢复链路需在 Session 层收敛 |
+| 对比项 | Pi (TypeScript / AgentSession) | Gong (Elixir / Session) | 覆盖状态 | 证据（实现/测试） |
+|------|----------------------------------|-------------------------|---------|------------------|
+| 会话生命周期 API | `start/prompt/history/restore/close` 一体化会话入口 | `Gong.Session` 暴露同等核心 API | ✅ 已覆盖 | `lib/gong/session.ex`, `test/gong/session_test.exs` |
+| 事件订阅与转发 | `subscribe(listener)` + EventEmitter | `subscribe(pid, subscriber)` + `Gong.Session.Events.from_stream_event/2` | ✅ 已覆盖 | `lib/gong/session.ex`, `lib/gong/session/events.ex`, `test/gong/session_test.exs` |
+| 可重试错误判断 (`isRetryableError()`) | 排除 context overflow，按错误模式判定可重试 | `Gong.Retry.classify_error/1` + `should_retry?/2` | ✅ 已覆盖 | `lib/gong/retry.ex`, `test/gong/retry_test.exs` |
+| 最后助手消息定位 (`getLastAssistantMessage()`) | 反向遍历，跳过 aborted 空消息 | BDD 已覆盖“跳过 aborted 空消息”语义 | ⚠️ 部分覆盖 | `docs/bdd/session_edge.dsl`(`SESSION-ERR-007`), `test/bdd_generated/session_edge_generated_test.exs`, `test/support/bdd/instructions_v1.ex` |
+| 会话恢复模型/思考级别 | 从 session entries 恢复 model + thinking level | 已持久化 initial_state；`Session.restore/2` 当前仅恢复 `history/turn_cursor/metadata` | ⚠️ 部分覆盖 | `docs/bdd/tape_session.dsl`(`SESSION-007`), `test/bdd_generated/tape_session_generated_test.exs`, `lib/gong/session.ex` |
 
 结论（分层）：
-- 职责模型：基本一致（Session 都是前端无关协调层）。
-- 运行时机制：不同（Pi 依赖 Node 事件循环，Gong 依赖 OTP）。
-- 接口契约：部分不同（错误返回风格、管理器接口组合）。
+- 设计目标：除运行时实现方式外，Session 职责与 Pi 保持一致（前端无关协调层）。
+- 运行时差异（不影响目标一致性）：Node Event Loop/AbortController vs OTP GenServer/mailbox/Task。
+- 功能闭环差异（当前唯一关键项）：`restore` 后 model/thinking 恢复链路尚未在 Session 层闭环。
 
 工程取舍：
 - Gong 借助 OTP（GenServer/Supervisor/mailbox）可减少手写并发与生命周期编排代码。
 - Pi 在 TypeScript 侧需要手写更多会话协调与事件管理逻辑。
+
+测试门禁说明（当前仓库）：
+- CI 仅门禁 BDD 生成测试：`.github/workflows/ci.yml` 执行 `mix test test/bdd_generated/ --trace --exclude e2e`
+- Session 单测（如 `test/gong/session_test.exs`、`test/gong/retry_test.exs`）用于本地回归与问题定位，不直接作为 CI merge gate
 
 ### 依赖关系
 

--- a/docs/架构设计.md
+++ b/docs/架构设计.md
@@ -497,27 +497,23 @@ defmodule Gong.Session do
 end
 ```
 
-### 2.6 与 Pi 的对比
+### 2.6 与 Pi 的对比（统一口径）
 
-| 功能 | Pi (TypeScript / AgentSession) | Gong (Elixir / Session) |
-|------|----------------------------------|-------------------------|
-| 进程模型 | 单线程 EventEmitter | GenServer |
-| 状态管理 | 类属性 | State struct |
-| 事件订阅 | `subscribe(listener)` | `subscribe(pid, listener)` |
-| 消息队列 | 数组 | List |
-| 异步处理 | async/await | Task + message |
-| 中断机制 | AbortController | process mailbox |
-| 重试错误判断 | `_isRetryableError()`（排除 context overflow，正则匹配可重试错误） | `Gong.Retry.classify_error/1` + `should_retry?/2` |
-| 最后助手消息定位 | `_findLastAssistantMessage()` 反向遍历消息 | 反向遍历历史；会话侧约束为“跳过 aborted 空消息” |
-| 会话恢复模型/思考级别 | 从 session entries 恢复 model + thinking level | 部分对齐：已定义初始状态持久化，完整恢复链路需在 Session 层收敛 |
+| 对比项 | Pi (TypeScript / AgentSession) | Gong (Elixir / Session) | 覆盖状态 | 证据（实现/测试） |
+|------|----------------------------------|-------------------------|---------|------------------|
+| 会话生命周期 API | `start/prompt/history/restore/close` 一体化会话入口 | `Gong.Session` 暴露同等核心 API | ✅ 已覆盖 | `lib/gong/session.ex`, `test/gong/session_test.exs` |
+| 事件订阅与转发 | `subscribe(listener)` + EventEmitter | `subscribe(pid, subscriber)` + `Gong.Session.Events.from_stream_event/2` | ✅ 已覆盖 | `lib/gong/session.ex`, `lib/gong/session/events.ex`, `test/gong/session_test.exs` |
+| 可重试错误判断 (`isRetryableError()`) | 排除 context overflow，按错误模式判定可重试 | `Gong.Retry.classify_error/1` + `should_retry?/2` | ✅ 已覆盖 | `lib/gong/retry.ex`, `test/gong/retry_test.exs` |
+| 最后助手消息定位 (`getLastAssistantMessage()`) | 反向遍历，跳过 aborted 空消息 | BDD 已覆盖“跳过 aborted 空消息”语义 | ⚠️ 部分覆盖 | `docs/bdd/session_edge.dsl`(`SESSION-ERR-007`), `test/bdd_generated/session_edge_generated_test.exs`, `test/support/bdd/instructions_v1.ex` |
+| 会话恢复模型/思考级别 | 从 session entries 恢复 model + thinking level | 已持久化 initial_state；`Session.restore/2` 当前仅恢复 `history/turn_cursor/metadata` | ⚠️ 部分覆盖 | `docs/bdd/tape_session.dsl`(`SESSION-007`), `test/bdd_generated/tape_session_generated_test.exs`, `lib/gong/session.ex` |
 
 结论（分层）：
-- 职责模型：基本一致（都把 Session 作为前端无关协调层）。
-- 运行时机制：不同（Node 事件循环 vs OTP 进程模型）。
-- 接口契约：部分不同（如错误返回风格、管理器接口组合）。
+- 设计目标：除运行时实现方式外，Session 职责与 Pi 保持一致（前端无关协调层）。
+- 运行时差异（不影响目标一致性）：Node Event Loop/AbortController vs OTP GenServer/mailbox/Task。
+- 功能闭环差异（当前唯一关键项）：`restore` 后 model/thinking 恢复链路尚未在 Session 层闭环。
 
 工程取舍：
-- Gong 依赖 OTP（GenServer/Supervisor/mailbox）后，很多生命周期、并发和容错逻辑可复用框架能力，代码更偏声明式。
+- Gong 依赖 OTP（GenServer/Supervisor/mailbox）后，可减少手写并发与生命周期编排代码。
 - Pi 在 TypeScript 侧需要手写更多会话协调与事件管理细节。
 
 ### 2.7 前端集成示例

--- a/docs/测试缺口分析.md
+++ b/docs/测试缺口分析.md
@@ -180,7 +180,10 @@
 
 ## 8. 会话/存储（pi 修了 22+ 个 bug）
 
-**Gong 现状：** 6 个场景，覆盖偏薄。
+**Gong 现状（已落地）：**
+- BDD：15 个场景（`SESSION-001~007` + `SESSION-ERR-001~008`）
+- Unit：`test/gong/session_test.exs`、`test/gong/retry_test.exs`
+- CI 门禁：仅执行 `test/bdd_generated/*`（单测不在 CI merge gate）
 
 **pi 踩过的坑：**
 - fork 写入父会话文件而非新文件，损坏父会话
@@ -196,13 +199,27 @@
 - SessionEntry 类型包含 SessionHeader 导致类型混乱（`9478a3c1`）
 - 会话管理器简化引入的回归（`0faadfcd`）
 
-**建议补充场景：**
-- [ ] SESSION-ERR-001: fork 后父会话内容不变
-- [ ] SESSION-ERR-002: fork 后用户消息保留
-- [ ] SESSION-ERR-003: 恢复会话时消息顺序正确
-- [ ] SESSION-ERR-004: 错误/中止的消息在会话树中可见
-- [ ] SESSION-ERR-005: 待处理消息在 session 切换时被清理
-- [ ] SESSION-ERR-006: 异步事件 handler 错误被正确传播而非静默吞掉
+**覆盖映射（可核对）：**
+
+| Pi 问题类型 | Gong 对应覆盖 | 状态 | 证据 |
+|------------|---------------|------|------|
+| fork 损坏父会话 | SESSION-ERR-001 | ✅ 已覆盖 | `docs/bdd/session_edge.dsl`, `test/bdd_generated/session_edge_generated_test.exs` |
+| fork 后消息丢失 | SESSION-ERR-002 | ✅ 已覆盖 | `docs/bdd/session_edge.dsl`, `test/bdd_generated/session_edge_generated_test.exs` |
+| 恢复后消息顺序错乱 | SESSION-ERR-003 | ✅ 已覆盖 | `docs/bdd/session_edge.dsl`, `test/bdd_generated/session_edge_generated_test.exs` |
+| 错误/中止消息被隐藏 | SESSION-ERR-004 | ✅ 已覆盖 | `docs/bdd/session_edge.dsl`, `test/bdd_generated/session_edge_generated_test.exs` |
+| session 切换未清理 pending | SESSION-ERR-005 | ✅ 已覆盖 | `docs/bdd/session_edge.dsl`, `test/bdd_generated/session_edge_generated_test.exs` |
+| 异步事件错误被吞掉 | SESSION-ERR-006 | ✅ 已覆盖 | `docs/bdd/session_edge.dsl`, `test/bdd_generated/session_edge_generated_test.exs` |
+| 最后 assistant 查找误命中 aborted 空消息 | SESSION-ERR-007 | ⚠️ 部分覆盖 | `docs/bdd/session_edge.dsl`, `test/support/bdd/instructions_v1.ex`（当前为测试运行时实现） |
+| flush 重置语义回归 | SESSION-ERR-008 | ⚠️ 部分覆盖 | `docs/bdd/session_edge.dsl`, `test/support/bdd/instructions_v1.ex`（当前为模拟校验） |
+| 初始 model/thinking 持久化 | SESSION-007 | ✅ 已覆盖 | `docs/bdd/tape_session.dsl`, `test/bdd_generated/tape_session_generated_test.exs` |
+
+**仍需补齐（建议新增 6 场景）：**
+- [ ] SESSION-ERR-009: `Session.restore/2` 后恢复 model 与 thinking level（不仅是 history/cursor/metadata）
+- [ ] SESSION-ERR-010: `--session` 恢复时同时加载历史消息与 model/thinking
+- [ ] SESSION-ERR-011: Session UUID 跨项目查找返回明确错误（非静默失败）
+- [ ] SESSION-ERR-012: model 存储格式保持 provider/model_id 分离并可逆恢复
+- [ ] SESSION-ERR-013: 会话分支摘要中止时返回结构化结果而非抛异常
+- [ ] SESSION-ERR-014: SessionEntry 类型约束避免 Header/Entry 混淆
 
 ---
 
@@ -303,7 +320,7 @@
 | 优先级 | 领域 | Gong 缺口 | 建议场景数 |
 |--------|------|-----------|-----------|
 | P0 | 令牌/成本/窗口 | 429 误触压缩、切割点越界、跨模型误触发 | 6 |
-| P0 | 会话/存储 | fork 损坏、消息丢失、session 切换泄漏 | 6 |
+| P0 | 会话/存储 | restore 恢复链路（model/thinking）、跨项目会话查找、存储格式可逆性 | 6 |
 | P1 | 工具调用边界 | 空参数、孤儿 result、异常 vs 错误返回 | 7 |
 | P1 | Bash 编码 | UTF-8 损坏、截断精度、进程组清理 | 4 |
 | P1 | Thinking | 跨厂商格式、budget 约束、级别持久化 | 3 |


### PR DESCRIPTION
## Summary
- 统一 Session 对比表口径
- 补齐 isRetryableError/getLastAssistantMessage/restore 覆盖说明
- 修正测试缺口分析为“已覆盖+待补齐”

## Test Plan
- 文档一致性自检（表头/条目/结论）
- 确认不含 .github/workflows 变更

Closes #14