### PR TITLE
fix: paginate PR marker lookup in niuma review workflow

### DIFF
--- a/.github/workflows/niuma-review.yml
+++ b/.github/workflows/niuma-review.yml
@@ -25,8 +25,9 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
-          PR_NUMBER=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
-            --jq '.[].body | select(contains("BOT:PR_CREATED"))' | grep -Eo 'pr=[0-9]+' | sed 's/pr=//' | tail -1)
+          PR_NUMBER=$(gh api --paginate "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            --jq '.[] | select(.body | contains("BOT:PR_CREATED")) | .body' \
+            | sed -n 's/.*pr=\([0-9]\+\).*/\1/p' | tail -1)
           if [ -z "$PR_NUMBER" ]; then
             echo "::warning::未在 issue #${ISSUE_NUMBER} 的评论中找到 PR 号"
           fi


### PR DESCRIPTION
## Summary
- fix `.github/workflows/niuma-review.yml` `Find PR Number` logic to read issue comments with `--paginate`
- parse `pr=<num>` from all `BOT:PR_CREATED` markers and select the latest one via `tail -1`
- prevent false "PR not found" on high-comment issues where marker appears after page 1

## Test plan
- local command validation on issue `#12`:
  - `gh api --paginate repos/biantaishabi2/gong/issues/12/comments ... | sed ... | tail -1`
  - expected and observed: `PR_NUMBER=22`
- workflow behavior expectation after merge:
  - `niuma - Review` should no longer skip `AI Self-Review` due to missing PR number on high-comment issues

Closes #23
