### PR TITLE
docs: 发布与回滚手册 + README 更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Gong.Retry          — 错误分类 + 重试策略
 Gong.Providers.*    — LLM Provider（DeepSeek，OpenAI 兼容）
 ```
 
+## 运行时要求
+
+- Erlang/OTP 26+
+- Elixir 1.17+（mix.exs 允许 >= 1.14）
+- ripgrep（grep 工具依赖）
+- `DEEPSEEK_API_KEY` 环境变量（实际运行需要）
+
 ## 快速开始
 
 ```bash
@@ -73,6 +80,13 @@ mix test test/bdd_generated/
 - [pi-mono](https://github.com/badlogic/pi-mono) — Mario Zechner 的 AI Agent 工具集，本项目的灵感来源
 - [Jido](https://github.com/agentjido/jido) — Elixir Agent 框架
 - [ReqLLM](https://hex.pm/packages/req_llm) — 多 Provider LLM 客户端
+
+## 文档
+
+- [架构设计](docs/架构设计.md) — 完整架构参考
+- [BDD 测试接入](docs/BDD测试接入.md) — DSL 测试体系与 CI 门禁
+- [实施计划](docs/实施计划.md) — 分阶段实施路径
+- [发布与回滚](docs/发布与回滚.md) — 安装、升级、回滚手册
 
 ## License
 

--- a/docs/发布与回滚.md
+++ b/docs/发布与回滚.md
@@ -1,0 +1,158 @@
+# Gong 发布与回滚手册
+
+## 版本信息
+
+- 当前版本：`0.1.0`
+- Elixir 要求：`>= 1.14.0 and < 2.0.0`
+- OTP 要求：`26+`
+- 运行时依赖：SQLite3（通过 exqlite 自动编译）
+
+---
+
+## 运行时要求
+
+| 组件 | 最低版本 | 说明 |
+|------|---------|------|
+| Erlang/OTP | 26 | CI 使用 OTP 26 |
+| Elixir | 1.17 | CI 使用 1.17，mix.exs 允许 >= 1.14 |
+| SQLite3 | 系统自带 | exqlite 编译时自动构建 |
+| ripgrep | 最新稳定版 | grep 工具 Action 依赖 |
+| bddc | 最新 | BDD 编译器（可选，仅开发/CI） |
+
+### 环境变量
+
+| 变量 | 必需 | 说明 |
+|------|------|------|
+| `DEEPSEEK_API_KEY` | 生产必需 | DeepSeek API 密钥，E2E 测试和实际运行需要 |
+
+---
+
+## 从零安装
+
+```bash
+# 1. 安装 Erlang/OTP 和 Elixir（推荐用 asdf 或 mise）
+asdf install erlang 26.2.5
+asdf install elixir 1.17.3-otp-26
+
+# 2. 安装系统依赖
+# Ubuntu/Debian
+sudo apt-get install -y ripgrep
+
+# macOS
+brew install ripgrep
+
+# 3. 克隆仓库
+git clone https://github.com/biantaishabi2/gong.git
+cd gong
+
+# 4. 安装 Elixir 依赖
+mix setup    # 等价于 mix deps.get
+
+# 5. 编译
+mix compile
+
+# 6. 验证安装
+mix test --exclude e2e
+```
+
+---
+
+## 构建发布包
+
+```bash
+# 构建 escript（单文件可执行）
+mix escript.build
+# 产出：./gong
+
+# 构建 OTP release
+MIX_ENV=prod mix release gong
+# 产出：_build/prod/rel/gong/
+```
+
+---
+
+## 升级步骤
+
+### 常规升级
+
+```bash
+# 1. 拉取最新代码
+git pull origin master
+
+# 2. 更新依赖
+mix deps.get
+
+# 3. 编译
+mix compile
+
+# 4. 运行测试确认无回归
+mix test --exclude e2e
+
+# 5. 重新构建（如使用 escript 或 release）
+mix escript.build
+# 或
+MIX_ENV=prod mix release gong --overwrite
+```
+
+### 数据库迁移
+
+Tape 存储使用 SQLite，索引文件随会话目录自动创建，无需手动迁移。如果 schema 变更导致旧索引不兼容：
+
+```bash
+# Tape 索引可从文件重建（数据以 JSONL 文件为主，SQLite 索引为辅）
+# 删除旧索引后，下次访问会自动重建
+rm -f <tape_dir>/index.db
+```
+
+---
+
+## 回滚方案
+
+### 代码回滚
+
+```bash
+# 回滚到指定版本
+git checkout <tag_or_commit>
+mix deps.get
+mix compile
+mix escript.build
+```
+
+### CI 门禁回滚
+
+如果新的 CI path-filter 或 quarantine 机制引入问题：
+
+```bash
+# 通过 workflow_dispatch 手动触发 legacy 模式
+# 在 GitHub Actions 页面选择 CI workflow → Run workflow → gate_mode: legacy
+```
+
+详见 `docs/BDD测试接入.md` 的「门禁模式」章节。
+
+### Tape 存储回滚
+
+Tape 采用双写设计（JSONL 文件 + SQLite 索引），文件为主、索引可重建：
+
+- 数据文件（`.jsonl`）是真相来源，不会因升级丢失
+- SQLite 索引损坏时删除 `index.db`，系统自动从文件重建
+- 会话目录结构向后兼容
+
+---
+
+## 发布检查清单
+
+- [ ] `mix compile --warnings-as-errors` 无警告
+- [ ] `mix test --exclude e2e` 全部通过
+- [ ] `bddc compile && git diff --exit-code -- test/bdd_generated` BDD 生成文件已同步
+- [ ] E2E 测试通过（需配置 `DEEPSEEK_API_KEY`）
+- [ ] 版本号已更新（`mix.exs` 中的 `version`）
+- [ ] CHANGELOG 已更新（如有）
+- [ ] README 中的测试场景数与实际一致
+
+---
+
+## 已知限制
+
+1. **单 Provider**：当前仅支持 DeepSeek（OpenAI 兼容协议），未来可扩展其他 Provider
+2. **无 CLI 发布包**：escript 构建可用但未正式发布到包管理器
+3. **Tape 索引不跨版本迁移**：schema 变更时需删除重建（数据不丢失）


### PR DESCRIPTION
## Summary
- 新增 `docs/发布与回滚.md`：运行时要求、从零安装、升级步骤、回滚方案、发布检查清单
- README 补充运行时要求章节和文档索引

Closes #15

## Test plan
- [ ] 按文档从零安装并运行 `mix test --exclude e2e` 通过
- [ ] 回滚步骤可执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)