### PR TITLE
feat: Step3 BDD 场景扩充 + Deepseek 集成测试

### DIFF
--- a/docs/bdd/cli_interactive.dsl
+++ b/docs/bdd/cli_interactive.dsl
@@ -255,6 +255,86 @@ GIVEN tape_init
 WHEN cli_session_restore session_id="nonexistent-id"
 THEN assert_session_restore_error error_contains="not_found"
 
+[SCENARIO: CLI-SESSION-005] TITLE: 多会话 list 排序 TAGS: integration cli session
+GIVEN create_temp_dir
+GIVEN tape_init
+GIVEN tape_append kind="user" content="问题A"
+GIVEN tape_append kind="assistant" content="回复A"
+GIVEN tape_save_session session_id="multi-001"
+GIVEN tape_append kind="user" content="问题B"
+GIVEN tape_append kind="assistant" content="回复B"
+GIVEN tape_save_session session_id="multi-002"
+WHEN cli_session_list
+THEN assert_session_list_count expected=2
+THEN assert_session_list_contains session_id="multi-001"
+THEN assert_session_list_contains session_id="multi-002"
+
+[SCENARIO: CLI-SESSION-006] TITLE: 覆盖保存同一 session_id TAGS: integration cli session
+GIVEN create_temp_dir
+GIVEN tape_init
+GIVEN tape_append kind="user" content="旧内容"
+GIVEN tape_save_session session_id="dup-001"
+GIVEN tape_append kind="user" content="新内容"
+GIVEN tape_append kind="assistant" content="新回复"
+GIVEN tape_save_session session_id="dup-001"
+WHEN cli_session_list
+THEN assert_session_list_count expected=1
+WHEN cli_session_restore session_id="dup-001"
+THEN assert_session_restored
+THEN assert_session_history_contains content="新内容"
+
+[SCENARIO: CLI-SESSION-007] TITLE: restore 验证 user + assistant 双角色 TAGS: integration cli session
+GIVEN create_temp_dir
+GIVEN tape_init
+GIVEN tape_append kind="user" content="用户提问"
+GIVEN tape_append kind="assistant" content="助手回复"
+GIVEN tape_save_session session_id="dual-role-001"
+WHEN cli_session_restore session_id="dual-role-001"
+THEN assert_session_restored
+THEN assert_session_history_contains content="用户提问"
+THEN assert_session_history_contains content="助手回复"
+
+[SCENARIO: CLI-SESSION-008] TITLE: 损坏 JSON 文件容错 TAGS: integration cli session
+GIVEN create_temp_dir
+GIVEN tape_init
+GIVEN tape_append kind="user" content="正常会话"
+GIVEN tape_append kind="assistant" content="正常回复"
+GIVEN tape_save_session session_id="good-session"
+GIVEN create_corrupt_session_file filename="bad-session.json"
+WHEN cli_session_list
+THEN assert_session_list_count expected=1
+THEN assert_session_list_contains session_id="good-session"
+
+[SCENARIO: CLI-SESSION-009] TITLE: save → restore 往返一致性 TAGS: integration cli session
+GIVEN create_temp_dir
+GIVEN tape_init
+GIVEN tape_append kind="user" content="往返问题"
+GIVEN tape_append kind="assistant" content="往返回复"
+GIVEN tape_save_session session_id="roundtrip-001"
+WHEN cli_session_restore session_id="roundtrip-001"
+THEN assert_session_restored
+THEN assert_session_history_contains content="往返问题"
+THEN assert_session_history_contains content="往返回复"
+
+[SCENARIO: CLI-SESSION-010] TITLE: 多轮对话 history TAGS: integration cli session
+GIVEN create_temp_dir
+GIVEN tape_init
+GIVEN tape_append kind="user" content="第一轮问题"
+GIVEN tape_append kind="assistant" content="第一轮回复"
+GIVEN tape_append kind="user" content="第二轮问题"
+GIVEN tape_append kind="assistant" content="第二轮回复"
+GIVEN tape_append kind="user" content="第三轮问题"
+GIVEN tape_append kind="assistant" content="第三轮回复"
+GIVEN tape_save_session session_id="multi-turn-001"
+WHEN cli_session_restore session_id="multi-turn-001"
+THEN assert_session_restored
+THEN assert_session_history_contains content="第一轮问题"
+THEN assert_session_history_contains content="第一轮回复"
+THEN assert_session_history_contains content="第二轮问题"
+THEN assert_session_history_contains content="第二轮回复"
+THEN assert_session_history_contains content="第三轮问题"
+THEN assert_session_history_contains content="第三轮回复"
+
 # ══════════════════════════════════════════════
 # Group 6: 长对话压缩 CLI 集成 — Step4 (3 场景)
 # ══════════════════════════════════════════════

--- a/docs/bdd/e2e_llm.dsl
+++ b/docs/bdd/e2e_llm.dsl
@@ -233,3 +233,19 @@ THEN assert_telemetry_received event="gong.tool.start" metadata_contains="read_f
 THEN assert_telemetry_received event="gong.tool.stop" metadata_contains="read_file"
 THEN assert_telemetry_received event="gong.agent.end"
 THEN assert_no_crash
+
+# ══════════════════════════════════════════════
+# Group 11: Session 端到端 (1 个)
+# ══════════════════════════════════════════════
+
+[SCENARIO: BDD-E2E-SESSION-001] TITLE: Deepseek 对话后保存恢复（完整 tape 链路） TAGS: e2e agent session
+GIVEN check_e2e_provider provider="deepseek"
+GIVEN create_temp_dir
+GIVEN tape_init
+GIVEN configure_agent
+WHEN agent_chat_live prompt="1+1等于几？只回答数字"
+WHEN e2e_tape_record_turn prompt="1+1等于几？只回答数字"
+GIVEN tape_save_session session_id="e2e-session-001"
+WHEN cli_session_restore session_id="e2e-session-001"
+THEN assert_session_restored
+THEN assert_session_history_contains content="2"

--- a/lib/gong/bdd/instruction_registries/agent_loop.ex
+++ b/lib/gong/bdd/instruction_registries/agent_loop.ex
@@ -408,6 +408,23 @@ defmodule Gong.BDD.InstructionRegistries.AgentLoop do
         assert_class: nil
       },
 
+      # ── WHEN: E2E Tape 记录轮次 ──
+
+      e2e_tape_record_turn: %{
+        name: :e2e_tape_record_turn,
+        kind: :when,
+        args: %{
+          prompt: %{type: :string, required?: true, allowed: nil}
+        },
+        outputs: %{},
+        rules: [],
+        boundary: :test_runtime,
+        scopes: [:e2e],
+        async?: false,
+        eventually?: false,
+        assert_class: nil
+      },
+
       # ── THEN: E2E Compaction 可触发性 ──
 
       assert_context_compactable: %{

--- a/lib/gong/bdd/instruction_registries/step2_cli.ex
+++ b/lib/gong/bdd/instruction_registries/step2_cli.ex
@@ -183,7 +183,7 @@ defmodule Gong.BDD.InstructionRegistries.Step2CLI do
           session_id: %{type: :string, required?: true, allowed: nil}
         },
         outputs: %{}, rules: [], boundary: :service,
-        scopes: [:unit, :integration], async?: false, eventually?: false, assert_class: nil
+        scopes: [:unit, :integration, :e2e], async?: false, eventually?: false, assert_class: nil
       },
       tape_save_session: %{
         name: :tape_save_session, kind: :given,
@@ -191,7 +191,7 @@ defmodule Gong.BDD.InstructionRegistries.Step2CLI do
           session_id: %{type: :string, required?: true, allowed: nil}
         },
         outputs: %{}, rules: [], boundary: :service,
-        scopes: [:unit, :integration], async?: false, eventually?: false, assert_class: nil
+        scopes: [:unit, :integration, :e2e], async?: false, eventually?: false, assert_class: nil
       },
       assert_session_list_count: %{
         name: :assert_session_list_count, kind: :then,
@@ -213,7 +213,7 @@ defmodule Gong.BDD.InstructionRegistries.Step2CLI do
         name: :assert_session_restored, kind: :then,
         args: %{},
         outputs: %{}, rules: [], boundary: :service,
-        scopes: [:unit, :integration], async?: false, eventually?: false, assert_class: :C
+        scopes: [:unit, :integration, :e2e], async?: false, eventually?: false, assert_class: :C
       },
       assert_session_history_contains: %{
         name: :assert_session_history_contains, kind: :then,
@@ -221,7 +221,7 @@ defmodule Gong.BDD.InstructionRegistries.Step2CLI do
           content: %{type: :string, required?: true, allowed: nil}
         },
         outputs: %{}, rules: [], boundary: :service,
-        scopes: [:unit, :integration], async?: false, eventually?: false, assert_class: :C
+        scopes: [:unit, :integration, :e2e], async?: false, eventually?: false, assert_class: :C
       },
       assert_session_restore_error: %{
         name: :assert_session_restore_error, kind: :then,
@@ -236,6 +236,17 @@ defmodule Gong.BDD.InstructionRegistries.Step2CLI do
         args: %{},
         outputs: %{}, rules: [], boundary: :service,
         scopes: [:unit, :integration], async?: false, eventually?: false, assert_class: :C
+      },
+
+      # ── Session 容错 ──
+
+      create_corrupt_session_file: %{
+        name: :create_corrupt_session_file, kind: :given,
+        args: %{
+          filename: %{type: :string, required?: true, allowed: nil}
+        },
+        outputs: %{}, rules: [], boundary: :service,
+        scopes: [:unit, :integration], async?: false, eventually?: false, assert_class: nil
       }
     }
   end

--- a/lib/gong/bdd/instruction_registries/tape.ex
+++ b/lib/gong/bdd/instruction_registries/tape.ex
@@ -12,7 +12,7 @@ defmodule Gong.BDD.InstructionRegistries.Tape do
         outputs: %{tape_store: :struct},
         rules: [],
         boundary: :test_runtime,
-        scopes: [:unit, :integration],
+        scopes: [:unit, :integration, :e2e],
         async?: false,
         eventually?: false,
         assert_class: nil

--- a/lib/gong/cli.ex
+++ b/lib/gong/cli.ex
@@ -9,6 +9,7 @@ defmodule Gong.CLI do
 
   alias Gong.Session
   alias Gong.Session.Events
+  alias Gong.CLI.SessionCmd
 
   @otp_min 25
   @elixir_min Version.parse!("1.14.0")
@@ -210,13 +211,47 @@ defmodule Gong.CLI do
     Gong.CLI.Run.run(prompt, opts)
   end
 
-  defp execute(%{command: :session_list, opts: _command_opts}, _runtime, _run_opts) do
-    IO.puts("(session list 未实现)")
+  defp execute(%{command: :session_list, opts: command_opts}, _runtime, run_opts) do
+    cwd = resolve_cwd(command_opts, run_opts)
+    tape_path = Path.join(cwd, ".gong/tape")
+
+    case SessionCmd.list_sessions(tape_path) do
+      {:ok, []} ->
+        IO.puts("没有已保存的会话")
+
+      {:ok, sessions} ->
+        IO.puts("已保存的会话 (#{length(sessions)}):")
+
+        Enum.each(sessions, fn s ->
+          id = s["session_id"] || "unknown"
+          saved_at = s["saved_at"]
+          time_str = if saved_at, do: " (#{format_timestamp(saved_at)})", else: ""
+          IO.puts("  #{id}#{time_str}")
+        end)
+    end
+
     @exit_ok
   end
 
-  defp execute(%{command: :session_restore, session_id: _id, opts: _command_opts}, _runtime, _run_opts) do
-    IO.puts("(session restore 未实现)")
+  defp execute(%{command: :session_restore, session_id: id, opts: command_opts}, _runtime, run_opts) do
+    cwd = resolve_cwd(command_opts, run_opts)
+    tape_path = Path.join(cwd, ".gong/tape")
+
+    case SessionCmd.restore_session(tape_path, id) do
+      {:ok, snapshot} ->
+        history = snapshot["history"] || []
+        IO.puts("会话 #{id} 已恢复 (#{length(history)} 条消息)")
+
+        Enum.each(history, fn entry ->
+          role = entry["role"] || "?"
+          content = entry["content"] || ""
+          IO.puts("[#{role}] #{content}")
+        end)
+
+      {:error, reason} ->
+        IO.puts(:stderr, "[错误] #{reason}")
+    end
+
     @exit_ok
   end
 
@@ -467,6 +502,15 @@ defmodule Gong.CLI do
     do: invalid_argument("timestamp 必须是毫秒正整数", "请传入 Unix 毫秒时间戳")
 
   defp payload_get(map, key), do: Events.payload_get(map, key)
+
+  defp format_timestamp(ms) when is_integer(ms) do
+    case DateTime.from_unix(ms, :millisecond) do
+      {:ok, dt} -> Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S")
+      _ -> "#{ms}"
+    end
+  end
+
+  defp format_timestamp(_), do: ""
 
   defp invalid_argument(message, hint) do
     {:error,

--- a/lib/gong/cli/chat.ex
+++ b/lib/gong/cli/chat.ex
@@ -119,6 +119,47 @@ defmodule Gong.CLI.Chat do
     repl_loop(session_pid)
   end
 
+  defp handle_input("/save", session_pid) do
+    case Session.history(session_pid) do
+      {:ok, history} ->
+        session_id = generate_session_id()
+        cwd = File.cwd!()
+        tape_path = Path.join(cwd, ".gong/tape")
+
+        # 转为快照格式
+        indexed_history =
+          history
+          |> Enum.with_index(1)
+          |> Enum.map(fn {entry, idx} ->
+            role = Map.get(entry, :role) || Map.get(entry, "role") || "?"
+            content = Map.get(entry, :content) || Map.get(entry, "content") || ""
+            turn_id = div(idx + 1, 2)
+
+            %{
+              "role" => to_string(role),
+              "content" => to_string(content),
+              "turn_id" => turn_id,
+              "ts" => System.os_time(:millisecond)
+            }
+          end)
+
+        snapshot = %{
+          "session_id" => session_id,
+          "history" => indexed_history,
+          "turn_cursor" => length(indexed_history),
+          "metadata" => %{}
+        }
+
+        :ok = Gong.CLI.SessionCmd.save_session(tape_path, session_id, snapshot)
+        IO.puts("会话已保存: #{session_id}")
+
+      {:error, _} ->
+        IO.puts("(无法获取历史，保存失败)")
+    end
+
+    repl_loop(session_pid)
+  end
+
   defp handle_input(text, session_pid) do
     # 普通输入，发送 prompt 并等待完成
     case Session.prompt(session_pid, text, []) do
@@ -149,6 +190,13 @@ defmodule Gong.CLI.Chat do
     end
   end
 
+  defp generate_session_id do
+    now = NaiveDateTime.utc_now()
+    hex = :crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)
+    ts = Calendar.strftime(now, "%Y%m%d_%H%M%S")
+    "session_#{ts}_#{hex}"
+  end
+
   defp help_text do
     """
     可用命令:
@@ -156,6 +204,7 @@ defmodule Gong.CLI.Chat do
       /help     查看帮助
       /history  查看对话历史
       /clear    清空对话
+      /save     保存当前会话
     """
   end
 end

--- a/lib/gong/cli/session_cmd.ex
+++ b/lib/gong/cli/session_cmd.ex
@@ -1,0 +1,74 @@
+defmodule Gong.CLI.SessionCmd do
+  @moduledoc """
+  会话持久化命令 — 列出/恢复/保存会话快照。
+
+  快照存放在 `{tape_path}/sessions/{session_id}.json`。
+  """
+
+  @sessions_dir "sessions"
+
+  @doc "列出所有已保存会话"
+  @spec list_sessions(Path.t()) :: {:ok, [map()]}
+  def list_sessions(workspace_path) do
+    dir = sessions_dir(workspace_path)
+
+    if File.dir?(dir) do
+      sessions =
+        dir
+        |> File.ls!()
+        |> Enum.filter(&String.ends_with?(&1, ".json"))
+        |> Enum.map(fn filename ->
+          path = Path.join(dir, filename)
+
+          case File.read(path) do
+            {:ok, content} ->
+              case Jason.decode(content) do
+                {:ok, data} -> data
+                _ -> nil
+              end
+
+            _ ->
+              nil
+          end
+        end)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.sort_by(& &1["saved_at"], :desc)
+
+      {:ok, sessions}
+    else
+      {:ok, []}
+    end
+  end
+
+  @doc "恢复指定会话"
+  @spec restore_session(Path.t(), String.t()) :: {:ok, map()} | {:error, String.t()}
+  def restore_session(workspace_path, session_id) do
+    path = session_file(workspace_path, session_id)
+
+    case File.read(path) do
+      {:ok, content} ->
+        case Jason.decode(content) do
+          {:ok, snapshot} -> {:ok, snapshot}
+          _ -> {:error, "not_found"}
+        end
+
+      {:error, _} ->
+        {:error, "not_found"}
+    end
+  end
+
+  @doc "保存会话快照"
+  @spec save_session(Path.t(), String.t(), map()) :: :ok
+  def save_session(workspace_path, session_id, snapshot) do
+    dir = sessions_dir(workspace_path)
+    File.mkdir_p!(dir)
+
+    path = session_file(workspace_path, session_id)
+    data = Map.put(snapshot, "saved_at", System.os_time(:millisecond))
+    File.write!(path, Jason.encode!(data, pretty: true))
+    :ok
+  end
+
+  defp sessions_dir(workspace_path), do: Path.join(workspace_path, @sessions_dir)
+  defp session_file(workspace_path, session_id), do: Path.join(sessions_dir(workspace_path), "#{session_id}.json")
+end

--- a/lib/gong/session/state.ex
+++ b/lib/gong/session/state.ex
@@ -1,0 +1,57 @@
+defmodule Gong.Session.State do
+  @moduledoc """
+  Session 进程状态。
+  """
+
+  @type runner_result ::
+          {:ok, String.t()}
+          | {:ok, String.t(), [Gong.Session.Events.t()]}
+          | {:error, term()}
+          | {:error, term(), [Gong.Session.Events.t()]}
+
+  @type runner :: (String.t(), t(), keyword() -> runner_result())
+
+  @type t :: %__MODULE__{
+          runner: runner(),
+          session_manager: term(),
+          settings_manager: term(),
+          steering_messages: [String.t()],
+          follow_up_messages: [String.t()],
+          pending_next_turn: [String.t()],
+          is_streaming: boolean(),
+          current_turn: non_neg_integer(),
+          compaction_opts: keyword(),
+          retry_opts: keyword(),
+          extension_runner: term(),
+          event_listeners: [{reference(), (Gong.Session.Events.t() -> any())}],
+          base_system_prompt: String.t(),
+          scoped_models: [String.t()],
+          cwd: String.t(),
+          model: String.t() | nil,
+          history: [map()],
+          inflight_call: GenServer.from() | nil,
+          inflight_task_ref: reference() | nil
+        }
+
+  defstruct [
+    runner: nil,
+    session_manager: nil,
+    settings_manager: nil,
+    steering_messages: [],
+    follow_up_messages: [],
+    pending_next_turn: [],
+    is_streaming: false,
+    current_turn: 0,
+    compaction_opts: [],
+    retry_opts: [],
+    extension_runner: nil,
+    event_listeners: [],
+    base_system_prompt: "",
+    scoped_models: [],
+    cwd: "",
+    model: nil,
+    history: [],
+    inflight_call: nil,
+    inflight_task_ref: nil
+  ]
+end

--- a/test/bdd_generated/cli_interactive_generated_test.exs
+++ b/test/bdd_generated/cli_interactive_generated_test.exs
@@ -685,6 +685,208 @@ defmodule Gong.BDD.Generated.CliInteractiveTest do
     :ok
   end
 
+  # Source: CLI-SESSION-005
+  @tag :cli
+  @tag :integration
+  @tag :session
+  test "[CLI-SESSION-005] 多会话 list 排序" do
+    run_id = Gong.BDD.Instructions.V1.new_run_id()
+    ctx = %{run_id: run_id, scenario_id: "CLI-SESSION-005"}
+    # line 259: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 259, raw: "GIVEN create_temp_dir"}, 259)
+    # line 260: GIVEN tape_init
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 260, raw: "GIVEN tape_init"}, 260)
+    # line 261: GIVEN tape_append kind="user" content="问题A"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "问题A", kind: "user"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 261, raw: "GIVEN tape_append kind=\"user\" content=\"问题A\""}, 261)
+    # line 262: GIVEN tape_append kind="assistant" content="回复A"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "回复A", kind: "assistant"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 262, raw: "GIVEN tape_append kind=\"assistant\" content=\"回复A\""}, 262)
+    # line 263: GIVEN tape_save_session session_id="multi-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_save_session, %{session_id: "multi-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 263, raw: "GIVEN tape_save_session session_id=\"multi-001\""}, 263)
+    # line 264: GIVEN tape_append kind="user" content="问题B"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "问题B", kind: "user"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 264, raw: "GIVEN tape_append kind=\"user\" content=\"问题B\""}, 264)
+    # line 265: GIVEN tape_append kind="assistant" content="回复B"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "回复B", kind: "assistant"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 265, raw: "GIVEN tape_append kind=\"assistant\" content=\"回复B\""}, 265)
+    # line 266: GIVEN tape_save_session session_id="multi-002"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_save_session, %{session_id: "multi-002"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 266, raw: "GIVEN tape_save_session session_id=\"multi-002\""}, 266)
+    # line 267: WHEN cli_session_list
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cli_session_list, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 267, raw: "WHEN cli_session_list"}, 267)
+    # line 268: THEN assert_session_list_count expected=2
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_list_count, %{expected: 2}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 268, raw: "THEN assert_session_list_count expected=2"}, 268)
+    # line 269: THEN assert_session_list_contains session_id="multi-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_list_contains, %{session_id: "multi-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 269, raw: "THEN assert_session_list_contains session_id=\"multi-001\""}, 269)
+    # line 270: THEN assert_session_list_contains session_id="multi-002"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_list_contains, %{session_id: "multi-002"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 270, raw: "THEN assert_session_list_contains session_id=\"multi-002\""}, 270)
+    _ctx = ctx
+    :ok
+  end
+
+  # Source: CLI-SESSION-006
+  @tag :cli
+  @tag :integration
+  @tag :session
+  test "[CLI-SESSION-006] 覆盖保存同一 session_id" do
+    run_id = Gong.BDD.Instructions.V1.new_run_id()
+    ctx = %{run_id: run_id, scenario_id: "CLI-SESSION-006"}
+    # line 273: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 273, raw: "GIVEN create_temp_dir"}, 273)
+    # line 274: GIVEN tape_init
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 274, raw: "GIVEN tape_init"}, 274)
+    # line 275: GIVEN tape_append kind="user" content="旧内容"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "旧内容", kind: "user"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 275, raw: "GIVEN tape_append kind=\"user\" content=\"旧内容\""}, 275)
+    # line 276: GIVEN tape_save_session session_id="dup-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_save_session, %{session_id: "dup-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 276, raw: "GIVEN tape_save_session session_id=\"dup-001\""}, 276)
+    # line 277: GIVEN tape_append kind="user" content="新内容"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "新内容", kind: "user"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 277, raw: "GIVEN tape_append kind=\"user\" content=\"新内容\""}, 277)
+    # line 278: GIVEN tape_append kind="assistant" content="新回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "新回复", kind: "assistant"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 278, raw: "GIVEN tape_append kind=\"assistant\" content=\"新回复\""}, 278)
+    # line 279: GIVEN tape_save_session session_id="dup-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_save_session, %{session_id: "dup-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 279, raw: "GIVEN tape_save_session session_id=\"dup-001\""}, 279)
+    # line 280: WHEN cli_session_list
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cli_session_list, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 280, raw: "WHEN cli_session_list"}, 280)
+    # line 281: THEN assert_session_list_count expected=1
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_list_count, %{expected: 1}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 281, raw: "THEN assert_session_list_count expected=1"}, 281)
+    # line 282: WHEN cli_session_restore session_id="dup-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cli_session_restore, %{session_id: "dup-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 282, raw: "WHEN cli_session_restore session_id=\"dup-001\""}, 282)
+    # line 283: THEN assert_session_restored
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_restored, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 283, raw: "THEN assert_session_restored"}, 283)
+    # line 284: THEN assert_session_history_contains content="新内容"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "新内容"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 284, raw: "THEN assert_session_history_contains content=\"新内容\""}, 284)
+    _ctx = ctx
+    :ok
+  end
+
+  # Source: CLI-SESSION-007
+  @tag :cli
+  @tag :integration
+  @tag :session
+  test "[CLI-SESSION-007] restore 验证 user + assistant 双角色" do
+    run_id = Gong.BDD.Instructions.V1.new_run_id()
+    ctx = %{run_id: run_id, scenario_id: "CLI-SESSION-007"}
+    # line 287: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 287, raw: "GIVEN create_temp_dir"}, 287)
+    # line 288: GIVEN tape_init
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 288, raw: "GIVEN tape_init"}, 288)
+    # line 289: GIVEN tape_append kind="user" content="用户提问"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "用户提问", kind: "user"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 289, raw: "GIVEN tape_append kind=\"user\" content=\"用户提问\""}, 289)
+    # line 290: GIVEN tape_append kind="assistant" content="助手回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "助手回复", kind: "assistant"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 290, raw: "GIVEN tape_append kind=\"assistant\" content=\"助手回复\""}, 290)
+    # line 291: GIVEN tape_save_session session_id="dual-role-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_save_session, %{session_id: "dual-role-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 291, raw: "GIVEN tape_save_session session_id=\"dual-role-001\""}, 291)
+    # line 292: WHEN cli_session_restore session_id="dual-role-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cli_session_restore, %{session_id: "dual-role-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 292, raw: "WHEN cli_session_restore session_id=\"dual-role-001\""}, 292)
+    # line 293: THEN assert_session_restored
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_restored, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 293, raw: "THEN assert_session_restored"}, 293)
+    # line 294: THEN assert_session_history_contains content="用户提问"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "用户提问"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 294, raw: "THEN assert_session_history_contains content=\"用户提问\""}, 294)
+    # line 295: THEN assert_session_history_contains content="助手回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "助手回复"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 295, raw: "THEN assert_session_history_contains content=\"助手回复\""}, 295)
+    _ctx = ctx
+    :ok
+  end
+
+  # Source: CLI-SESSION-008
+  @tag :cli
+  @tag :integration
+  @tag :session
+  test "[CLI-SESSION-008] 损坏 JSON 文件容错" do
+    run_id = Gong.BDD.Instructions.V1.new_run_id()
+    ctx = %{run_id: run_id, scenario_id: "CLI-SESSION-008"}
+    # line 298: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 298, raw: "GIVEN create_temp_dir"}, 298)
+    # line 299: GIVEN tape_init
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 299, raw: "GIVEN tape_init"}, 299)
+    # line 300: GIVEN tape_append kind="user" content="正常会话"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "正常会话", kind: "user"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 300, raw: "GIVEN tape_append kind=\"user\" content=\"正常会话\""}, 300)
+    # line 301: GIVEN tape_append kind="assistant" content="正常回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "正常回复", kind: "assistant"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 301, raw: "GIVEN tape_append kind=\"assistant\" content=\"正常回复\""}, 301)
+    # line 302: GIVEN tape_save_session session_id="good-session"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_save_session, %{session_id: "good-session"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 302, raw: "GIVEN tape_save_session session_id=\"good-session\""}, 302)
+    # line 303: GIVEN create_corrupt_session_file filename="bad-session.json"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_corrupt_session_file, %{filename: "bad-session.json"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 303, raw: "GIVEN create_corrupt_session_file filename=\"bad-session.json\""}, 303)
+    # line 304: WHEN cli_session_list
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cli_session_list, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 304, raw: "WHEN cli_session_list"}, 304)
+    # line 305: THEN assert_session_list_count expected=1
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_list_count, %{expected: 1}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 305, raw: "THEN assert_session_list_count expected=1"}, 305)
+    # line 306: THEN assert_session_list_contains session_id="good-session"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_list_contains, %{session_id: "good-session"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 306, raw: "THEN assert_session_list_contains session_id=\"good-session\""}, 306)
+    _ctx = ctx
+    :ok
+  end
+
+  # Source: CLI-SESSION-009
+  @tag :cli
+  @tag :integration
+  @tag :session
+  test "[CLI-SESSION-009] save → restore 往返一致性" do
+    run_id = Gong.BDD.Instructions.V1.new_run_id()
+    ctx = %{run_id: run_id, scenario_id: "CLI-SESSION-009"}
+    # line 309: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 309, raw: "GIVEN create_temp_dir"}, 309)
+    # line 310: GIVEN tape_init
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 310, raw: "GIVEN tape_init"}, 310)
+    # line 311: GIVEN tape_append kind="user" content="往返问题"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "往返问题", kind: "user"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 311, raw: "GIVEN tape_append kind=\"user\" content=\"往返问题\""}, 311)
+    # line 312: GIVEN tape_append kind="assistant" content="往返回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "往返回复", kind: "assistant"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 312, raw: "GIVEN tape_append kind=\"assistant\" content=\"往返回复\""}, 312)
+    # line 313: GIVEN tape_save_session session_id="roundtrip-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_save_session, %{session_id: "roundtrip-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 313, raw: "GIVEN tape_save_session session_id=\"roundtrip-001\""}, 313)
+    # line 314: WHEN cli_session_restore session_id="roundtrip-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cli_session_restore, %{session_id: "roundtrip-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 314, raw: "WHEN cli_session_restore session_id=\"roundtrip-001\""}, 314)
+    # line 315: THEN assert_session_restored
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_restored, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 315, raw: "THEN assert_session_restored"}, 315)
+    # line 316: THEN assert_session_history_contains content="往返问题"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "往返问题"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 316, raw: "THEN assert_session_history_contains content=\"往返问题\""}, 316)
+    # line 317: THEN assert_session_history_contains content="往返回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "往返回复"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 317, raw: "THEN assert_session_history_contains content=\"往返回复\""}, 317)
+    _ctx = ctx
+    :ok
+  end
+
+  # Source: CLI-SESSION-010
+  @tag :cli
+  @tag :integration
+  @tag :session
+  test "[CLI-SESSION-010] 多轮对话 history" do
+    run_id = Gong.BDD.Instructions.V1.new_run_id()
+    ctx = %{run_id: run_id, scenario_id: "CLI-SESSION-010"}
+    # line 320: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 320, raw: "GIVEN create_temp_dir"}, 320)
+    # line 321: GIVEN tape_init
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 321, raw: "GIVEN tape_init"}, 321)
+    # line 322: GIVEN tape_append kind="user" content="第一轮问题"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "第一轮问题", kind: "user"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 322, raw: "GIVEN tape_append kind=\"user\" content=\"第一轮问题\""}, 322)
+    # line 323: GIVEN tape_append kind="assistant" content="第一轮回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "第一轮回复", kind: "assistant"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 323, raw: "GIVEN tape_append kind=\"assistant\" content=\"第一轮回复\""}, 323)
+    # line 324: GIVEN tape_append kind="user" content="第二轮问题"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "第二轮问题", kind: "user"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 324, raw: "GIVEN tape_append kind=\"user\" content=\"第二轮问题\""}, 324)
+    # line 325: GIVEN tape_append kind="assistant" content="第二轮回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "第二轮回复", kind: "assistant"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 325, raw: "GIVEN tape_append kind=\"assistant\" content=\"第二轮回复\""}, 325)
+    # line 326: GIVEN tape_append kind="user" content="第三轮问题"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "第三轮问题", kind: "user"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 326, raw: "GIVEN tape_append kind=\"user\" content=\"第三轮问题\""}, 326)
+    # line 327: GIVEN tape_append kind="assistant" content="第三轮回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_append, %{content: "第三轮回复", kind: "assistant"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 327, raw: "GIVEN tape_append kind=\"assistant\" content=\"第三轮回复\""}, 327)
+    # line 328: GIVEN tape_save_session session_id="multi-turn-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_save_session, %{session_id: "multi-turn-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 328, raw: "GIVEN tape_save_session session_id=\"multi-turn-001\""}, 328)
+    # line 329: WHEN cli_session_restore session_id="multi-turn-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cli_session_restore, %{session_id: "multi-turn-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 329, raw: "WHEN cli_session_restore session_id=\"multi-turn-001\""}, 329)
+    # line 330: THEN assert_session_restored
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_restored, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 330, raw: "THEN assert_session_restored"}, 330)
+    # line 331: THEN assert_session_history_contains content="第一轮问题"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "第一轮问题"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 331, raw: "THEN assert_session_history_contains content=\"第一轮问题\""}, 331)
+    # line 332: THEN assert_session_history_contains content="第一轮回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "第一轮回复"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 332, raw: "THEN assert_session_history_contains content=\"第一轮回复\""}, 332)
+    # line 333: THEN assert_session_history_contains content="第二轮问题"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "第二轮问题"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 333, raw: "THEN assert_session_history_contains content=\"第二轮问题\""}, 333)
+    # line 334: THEN assert_session_history_contains content="第二轮回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "第二轮回复"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 334, raw: "THEN assert_session_history_contains content=\"第二轮回复\""}, 334)
+    # line 335: THEN assert_session_history_contains content="第三轮问题"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "第三轮问题"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 335, raw: "THEN assert_session_history_contains content=\"第三轮问题\""}, 335)
+    # line 336: THEN assert_session_history_contains content="第三轮回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "第三轮回复"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 336, raw: "THEN assert_session_history_contains content=\"第三轮回复\""}, 336)
+    _ctx = ctx
+    :ok
+  end
+
   # Source: CLI-COMPACT-001
   @tag :cli
   @tag :compaction
@@ -692,22 +894,22 @@ defmodule Gong.BDD.Generated.CliInteractiveTest do
   test "[CLI-COMPACT-001] chat 长对话自动触发压缩" do
     run_id = Gong.BDD.Instructions.V1.new_run_id()
     ctx = %{run_id: run_id, scenario_id: "CLI-COMPACT-001"}
-    # line 263: GIVEN create_temp_dir
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 263, raw: "GIVEN create_temp_dir"}, 263)
-    # line 264: GIVEN configure_agent context_window=200 reserve_tokens=50
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :configure_agent, %{context_window: 200, reserve_tokens: 50}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 264, raw: "GIVEN configure_agent context_window=200 reserve_tokens=50"}, 264)
-    # line 265: GIVEN start_chat_session
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :start_chat_session, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 265, raw: "GIVEN start_chat_session"}, 265)
-    # line 266: GIVEN mock_llm_response response_type="text" content="这是一段很长的回复用于触发压缩检测当上下文令牌数超过预设预算时系统应自动执行压缩"
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :mock_llm_response, %{content: "这是一段很长的回复用于触发压缩检测当上下文令牌数超过预设预算时系统应自动执行压缩", response_type: "text"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 266, raw: "GIVEN mock_llm_response response_type=\"text\" content=\"这是一段很长的回复用于触发压缩检测当上下文令牌数超过预设预算时系统应自动执行压缩\""}, 266)
-    # line 267: WHEN chat_input text="生成长回复"
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "生成长回复"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 267, raw: "WHEN chat_input text=\"生成长回复\""}, 267)
-    # line 268: WHEN chat_wait_completion
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_wait_completion, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 268, raw: "WHEN chat_wait_completion"}, 268)
-    # line 269: THEN assert_compaction_triggered
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_compaction_triggered, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 269, raw: "THEN assert_compaction_triggered"}, 269)
-    # line 270: THEN assert_no_crash
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_no_crash, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 270, raw: "THEN assert_no_crash"}, 270)
+    # line 343: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 343, raw: "GIVEN create_temp_dir"}, 343)
+    # line 344: GIVEN configure_agent context_window=200 reserve_tokens=50
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :configure_agent, %{context_window: 200, reserve_tokens: 50}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 344, raw: "GIVEN configure_agent context_window=200 reserve_tokens=50"}, 344)
+    # line 345: GIVEN start_chat_session
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :start_chat_session, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 345, raw: "GIVEN start_chat_session"}, 345)
+    # line 346: GIVEN mock_llm_response response_type="text" content="这是一段很长的回复用于触发压缩检测当上下文令牌数超过预设预算时系统应自动执行压缩"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :mock_llm_response, %{content: "这是一段很长的回复用于触发压缩检测当上下文令牌数超过预设预算时系统应自动执行压缩", response_type: "text"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 346, raw: "GIVEN mock_llm_response response_type=\"text\" content=\"这是一段很长的回复用于触发压缩检测当上下文令牌数超过预设预算时系统应自动执行压缩\""}, 346)
+    # line 347: WHEN chat_input text="生成长回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "生成长回复"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 347, raw: "WHEN chat_input text=\"生成长回复\""}, 347)
+    # line 348: WHEN chat_wait_completion
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_wait_completion, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 348, raw: "WHEN chat_wait_completion"}, 348)
+    # line 349: THEN assert_compaction_triggered
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_compaction_triggered, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 349, raw: "THEN assert_compaction_triggered"}, 349)
+    # line 350: THEN assert_no_crash
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_no_crash, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 350, raw: "THEN assert_no_crash"}, 350)
     _ctx = ctx
     :ok
   end
@@ -719,28 +921,28 @@ defmodule Gong.BDD.Generated.CliInteractiveTest do
   test "[CLI-COMPACT-002] 压缩后 chat 继续正常对话" do
     run_id = Gong.BDD.Instructions.V1.new_run_id()
     ctx = %{run_id: run_id, scenario_id: "CLI-COMPACT-002"}
-    # line 273: GIVEN create_temp_dir
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 273, raw: "GIVEN create_temp_dir"}, 273)
-    # line 274: GIVEN configure_agent context_window=200 reserve_tokens=50
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :configure_agent, %{context_window: 200, reserve_tokens: 50}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 274, raw: "GIVEN configure_agent context_window=200 reserve_tokens=50"}, 274)
-    # line 275: GIVEN start_chat_session
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :start_chat_session, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 275, raw: "GIVEN start_chat_session"}, 275)
-    # line 276: GIVEN mock_llm_response response_type="text" content="超长回复触发压缩后的第一轮内容用于填充上下文窗口"
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :mock_llm_response, %{content: "超长回复触发压缩后的第一轮内容用于填充上下文窗口", response_type: "text"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 276, raw: "GIVEN mock_llm_response response_type=\"text\" content=\"超长回复触发压缩后的第一轮内容用于填充上下文窗口\""}, 276)
-    # line 277: GIVEN mock_llm_response response_type="text" content="压缩后继续正常"
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :mock_llm_response, %{content: "压缩后继续正常", response_type: "text"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 277, raw: "GIVEN mock_llm_response response_type=\"text\" content=\"压缩后继续正常\""}, 277)
-    # line 278: WHEN chat_input text="第一轮"
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "第一轮"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 278, raw: "WHEN chat_input text=\"第一轮\""}, 278)
-    # line 279: WHEN chat_wait_completion
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_wait_completion, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 279, raw: "WHEN chat_wait_completion"}, 279)
-    # line 280: WHEN chat_input text="第二轮"
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "第二轮"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 280, raw: "WHEN chat_input text=\"第二轮\""}, 280)
-    # line 281: WHEN chat_wait_completion
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_wait_completion, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 281, raw: "WHEN chat_wait_completion"}, 281)
-    # line 282: THEN assert_agent_reply contains="压缩后继续正常"
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_agent_reply, %{contains: "压缩后继续正常"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 282, raw: "THEN assert_agent_reply contains=\"压缩后继续正常\""}, 282)
-    # line 283: THEN assert_no_crash
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_no_crash, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 283, raw: "THEN assert_no_crash"}, 283)
+    # line 353: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 353, raw: "GIVEN create_temp_dir"}, 353)
+    # line 354: GIVEN configure_agent context_window=200 reserve_tokens=50
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :configure_agent, %{context_window: 200, reserve_tokens: 50}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 354, raw: "GIVEN configure_agent context_window=200 reserve_tokens=50"}, 354)
+    # line 355: GIVEN start_chat_session
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :start_chat_session, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 355, raw: "GIVEN start_chat_session"}, 355)
+    # line 356: GIVEN mock_llm_response response_type="text" content="超长回复触发压缩后的第一轮内容用于填充上下文窗口"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :mock_llm_response, %{content: "超长回复触发压缩后的第一轮内容用于填充上下文窗口", response_type: "text"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 356, raw: "GIVEN mock_llm_response response_type=\"text\" content=\"超长回复触发压缩后的第一轮内容用于填充上下文窗口\""}, 356)
+    # line 357: GIVEN mock_llm_response response_type="text" content="压缩后继续正常"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :mock_llm_response, %{content: "压缩后继续正常", response_type: "text"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 357, raw: "GIVEN mock_llm_response response_type=\"text\" content=\"压缩后继续正常\""}, 357)
+    # line 358: WHEN chat_input text="第一轮"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "第一轮"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 358, raw: "WHEN chat_input text=\"第一轮\""}, 358)
+    # line 359: WHEN chat_wait_completion
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_wait_completion, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 359, raw: "WHEN chat_wait_completion"}, 359)
+    # line 360: WHEN chat_input text="第二轮"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "第二轮"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 360, raw: "WHEN chat_input text=\"第二轮\""}, 360)
+    # line 361: WHEN chat_wait_completion
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_wait_completion, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 361, raw: "WHEN chat_wait_completion"}, 361)
+    # line 362: THEN assert_agent_reply contains="压缩后继续正常"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_agent_reply, %{contains: "压缩后继续正常"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 362, raw: "THEN assert_agent_reply contains=\"压缩后继续正常\""}, 362)
+    # line 363: THEN assert_no_crash
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_no_crash, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 363, raw: "THEN assert_no_crash"}, 363)
     _ctx = ctx
     :ok
   end
@@ -753,26 +955,26 @@ defmodule Gong.BDD.Generated.CliInteractiveTest do
   test "[CLI-COMPACT-003] /save 保存压缩后的会话" do
     run_id = Gong.BDD.Instructions.V1.new_run_id()
     ctx = %{run_id: run_id, scenario_id: "CLI-COMPACT-003"}
-    # line 286: GIVEN create_temp_dir
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 286, raw: "GIVEN create_temp_dir"}, 286)
-    # line 287: GIVEN tape_init
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 287, raw: "GIVEN tape_init"}, 287)
-    # line 288: GIVEN configure_agent context_window=200 reserve_tokens=50
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :configure_agent, %{context_window: 200, reserve_tokens: 50}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 288, raw: "GIVEN configure_agent context_window=200 reserve_tokens=50"}, 288)
-    # line 289: GIVEN start_chat_session
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :start_chat_session, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 289, raw: "GIVEN start_chat_session"}, 289)
-    # line 290: GIVEN mock_llm_response response_type="text" content="压缩前的长回复内容用于填充上下文"
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :mock_llm_response, %{content: "压缩前的长回复内容用于填充上下文", response_type: "text"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 290, raw: "GIVEN mock_llm_response response_type=\"text\" content=\"压缩前的长回复内容用于填充上下文\""}, 290)
-    # line 291: WHEN chat_input text="触发压缩"
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "触发压缩"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 291, raw: "WHEN chat_input text=\"触发压缩\""}, 291)
-    # line 292: WHEN chat_wait_completion
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_wait_completion, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 292, raw: "WHEN chat_wait_completion"}, 292)
-    # line 293: WHEN chat_input text="/save"
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "/save"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 293, raw: "WHEN chat_input text=\"/save\""}, 293)
-    # line 294: THEN assert_session_saved
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_saved, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 294, raw: "THEN assert_session_saved"}, 294)
-    # line 295: THEN assert_no_crash
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_no_crash, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 295, raw: "THEN assert_no_crash"}, 295)
+    # line 366: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 366, raw: "GIVEN create_temp_dir"}, 366)
+    # line 367: GIVEN tape_init
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 367, raw: "GIVEN tape_init"}, 367)
+    # line 368: GIVEN configure_agent context_window=200 reserve_tokens=50
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :configure_agent, %{context_window: 200, reserve_tokens: 50}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 368, raw: "GIVEN configure_agent context_window=200 reserve_tokens=50"}, 368)
+    # line 369: GIVEN start_chat_session
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :start_chat_session, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 369, raw: "GIVEN start_chat_session"}, 369)
+    # line 370: GIVEN mock_llm_response response_type="text" content="压缩前的长回复内容用于填充上下文"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :mock_llm_response, %{content: "压缩前的长回复内容用于填充上下文", response_type: "text"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 370, raw: "GIVEN mock_llm_response response_type=\"text\" content=\"压缩前的长回复内容用于填充上下文\""}, 370)
+    # line 371: WHEN chat_input text="触发压缩"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "触发压缩"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 371, raw: "WHEN chat_input text=\"触发压缩\""}, 371)
+    # line 372: WHEN chat_wait_completion
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_wait_completion, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 372, raw: "WHEN chat_wait_completion"}, 372)
+    # line 373: WHEN chat_input text="/save"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "/save"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 373, raw: "WHEN chat_input text=\"/save\""}, 373)
+    # line 374: THEN assert_session_saved
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_saved, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 374, raw: "THEN assert_session_saved"}, 374)
+    # line 375: THEN assert_no_crash
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_no_crash, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 375, raw: "THEN assert_no_crash"}, 375)
     _ctx = ctx
     :ok
   end

--- a/test/bdd_generated/e2e_llm_generated_test.exs
+++ b/test/bdd_generated/e2e_llm_generated_test.exs
@@ -516,4 +516,35 @@ defmodule Gong.BDD.Generated.E2eLlmTest do
     :ok
   end
 
+  # Source: BDD-E2E-SESSION-001
+  @tag :agent
+  @tag :e2e
+  @tag :session
+  test "[BDD-E2E-SESSION-001] Deepseek 对话后保存恢复（完整 tape 链路）" do
+    run_id = Gong.BDD.Instructions.V1.new_run_id()
+    ctx = %{run_id: run_id, scenario_id: "BDD-E2E-SESSION-001"}
+    # line 242: GIVEN check_e2e_provider provider="deepseek"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :check_e2e_provider, %{provider: "deepseek"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 242, raw: "GIVEN check_e2e_provider provider=\"deepseek\""}, 242)
+    # line 243: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 243, raw: "GIVEN create_temp_dir"}, 243)
+    # line 244: GIVEN tape_init
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 244, raw: "GIVEN tape_init"}, 244)
+    # line 245: GIVEN configure_agent
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :configure_agent, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 245, raw: "GIVEN configure_agent"}, 245)
+    # line 246: WHEN agent_chat_live prompt="1+1等于几？只回答数字"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :agent_chat_live, %{prompt: "1+1等于几？只回答数字"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 246, raw: "WHEN agent_chat_live prompt=\"1+1等于几？只回答数字\""}, 246)
+    # line 247: WHEN e2e_tape_record_turn prompt="1+1等于几？只回答数字"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :e2e_tape_record_turn, %{prompt: "1+1等于几？只回答数字"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 247, raw: "WHEN e2e_tape_record_turn prompt=\"1+1等于几？只回答数字\""}, 247)
+    # line 248: GIVEN tape_save_session session_id="e2e-session-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_save_session, %{session_id: "e2e-session-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 248, raw: "GIVEN tape_save_session session_id=\"e2e-session-001\""}, 248)
+    # line 249: WHEN cli_session_restore session_id="e2e-session-001"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cli_session_restore, %{session_id: "e2e-session-001"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 249, raw: "WHEN cli_session_restore session_id=\"e2e-session-001\""}, 249)
+    # line 250: THEN assert_session_restored
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_restored, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 250, raw: "THEN assert_session_restored"}, 250)
+    # line 251: THEN assert_session_history_contains content="2"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "2"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 251, raw: "THEN assert_session_history_contains content=\"2\""}, 251)
+    _ctx = ctx
+    :ok
+  end
+
 end

--- a/test/support/bdd/instructions_v1.ex
+++ b/test/support/bdd/instructions_v1.ex
@@ -836,6 +836,9 @@ defmodule Gong.BDD.Instructions.V1 do
       {:when, :agent_chat_continue} ->
         agent_chat_continue!(ctx, args, meta)
 
+      {:when, :e2e_tape_record_turn} ->
+        e2e_tape_record_turn!(ctx, args, meta)
+
       {:then, :assert_context_compactable} ->
         assert_context_compactable!(ctx, args, meta)
 
@@ -1723,31 +1726,34 @@ defmodule Gong.BDD.Instructions.V1 do
       {:then, :assert_no_agent_call} ->
         assert_no_agent_call!(ctx, args, meta)
 
-      # ── Step3/4 占位（仅标记跳过）──
-
-      {:when, :cli_session_list} ->
-        raise ExUnit.AssertionError, message: "Step3 未实现: cli_session_list"
-
-      {:when, :cli_session_restore} ->
-        raise ExUnit.AssertionError, message: "Step3 未实现: cli_session_restore"
+      # ── Step3: Session 会话管理 ──
 
       {:given, :tape_save_session} ->
-        raise ExUnit.AssertionError, message: "Step3 未实现: tape_save_session"
+        tape_save_session!(ctx, args, meta)
+
+      {:when, :cli_session_list} ->
+        cli_session_list!(ctx, args, meta)
+
+      {:when, :cli_session_restore} ->
+        cli_session_restore!(ctx, args, meta)
 
       {:then, :assert_session_list_count} ->
-        raise ExUnit.AssertionError, message: "Step3 未实现: assert_session_list_count"
+        assert_session_list_count!(ctx, args, meta)
 
       {:then, :assert_session_list_contains} ->
-        raise ExUnit.AssertionError, message: "Step3 未实现: assert_session_list_contains"
+        assert_session_list_contains!(ctx, args, meta)
 
       {:then, :assert_session_restored} ->
-        raise ExUnit.AssertionError, message: "Step3 未实现: assert_session_restored"
+        assert_session_restored!(ctx, args, meta)
 
       {:then, :assert_session_history_contains} ->
-        raise ExUnit.AssertionError, message: "Step3 未实现: assert_session_history_contains"
+        assert_session_history_contains!(ctx, args, meta)
 
       {:then, :assert_session_restore_error} ->
-        raise ExUnit.AssertionError, message: "Step3 未实现: assert_session_restore_error"
+        assert_session_restore_error!(ctx, args, meta)
+
+      {:given, :create_corrupt_session_file} ->
+        create_corrupt_session_file!(ctx, args, meta)
 
       {:then, :assert_session_saved} ->
         raise ExUnit.AssertionError, message: "Step4 未实现: assert_session_saved"
@@ -2938,6 +2944,115 @@ defmodule Gong.BDD.Instructions.V1 do
       {:error, reason} ->
         Map.put(ctx, :tape_last_error, reason)
     end
+  end
+
+  # ── Step3: Session 会话管理实现 ──
+
+  defp tape_save_session!(ctx, args, _meta) do
+    store = ctx.tape_store
+    session_id = args.session_id
+    tape_path = ctx.tape_path
+
+    # 读取当前 anchor 范围内的所有 entries
+    anchor = Map.get(ctx, :tape_last_anchor, "session-start")
+    {:ok, entries} = Gong.Tape.Store.between_anchors(store, "session-start", anchor)
+
+    # 转为 history 格式
+    history =
+      entries
+      |> Enum.with_index(1)
+      |> Enum.map(fn {entry, idx} ->
+        turn_id = div(idx + 1, 2)
+
+        %{
+          "role" => to_string(entry.kind),
+          "content" => to_string(entry.content),
+          "turn_id" => turn_id,
+          "ts" => entry.timestamp
+        }
+      end)
+
+    snapshot = %{
+      "session_id" => session_id,
+      "history" => history,
+      "turn_cursor" => length(history),
+      "metadata" => %{}
+    }
+
+    :ok = Gong.CLI.SessionCmd.save_session(tape_path, session_id, snapshot)
+    ctx
+  end
+
+  defp cli_session_list!(ctx, _args, _meta) do
+    tape_path = ctx.tape_path
+    {:ok, sessions} = Gong.CLI.SessionCmd.list_sessions(tape_path)
+
+    ctx
+    |> Map.put(:session_list, sessions)
+    |> Map.put(:session_list_count, length(sessions))
+  end
+
+  defp cli_session_restore!(ctx, args, _meta) do
+    tape_path = ctx.tape_path
+    session_id = args.session_id
+
+    case Gong.CLI.SessionCmd.restore_session(tape_path, session_id) do
+      {:ok, snapshot} ->
+        ctx
+        |> Map.put(:session_restored, true)
+        |> Map.put(:session_snapshot, snapshot)
+
+      {:error, reason} ->
+        ctx
+        |> Map.put(:session_restored, false)
+        |> Map.put(:session_restore_error, reason)
+    end
+  end
+
+  defp assert_session_list_count!(ctx, args, _meta) do
+    expected = args.expected
+    actual = ctx.session_list_count
+    assert actual == expected, "期望 session 列表数量 #{expected}，实际 #{actual}"
+    ctx
+  end
+
+  defp assert_session_list_contains!(ctx, args, _meta) do
+    session_id = args.session_id
+    ids = Enum.map(ctx.session_list, & &1["session_id"])
+    assert session_id in ids, "session 列表不包含 #{session_id}，实际: #{inspect(ids)}"
+    ctx
+  end
+
+  defp assert_session_restored!(ctx, _args, _meta) do
+    assert ctx.session_restored == true, "期望 session 已恢复，但未恢复"
+    ctx
+  end
+
+  defp assert_session_history_contains!(ctx, args, _meta) do
+    content = args.content
+    snapshot = ctx.session_snapshot
+    history = snapshot["history"]
+    contents = Enum.map(history, & &1["content"])
+    assert content in contents, "session history 不包含 #{inspect(content)}，实际: #{inspect(contents)}"
+    ctx
+  end
+
+  defp assert_session_restore_error!(ctx, args, _meta) do
+    error_contains = args.error_contains
+    error = ctx.session_restore_error
+    assert String.contains?(to_string(error), error_contains),
+      "期望错误包含 #{inspect(error_contains)}，实际: #{inspect(error)}"
+    ctx
+  end
+
+  defp create_corrupt_session_file!(ctx, args, _meta) do
+    tape_path = ctx.tape_path
+    filename = args.filename
+    sessions_dir = Path.join(tape_path, "sessions")
+    File.mkdir_p!(sessions_dir)
+    corrupt_path = Path.join(sessions_dir, filename)
+    File.write!(corrupt_path, "{invalid json content <<<>>>")
+    ctx
   end
 
   defp tape_handoff_given!(ctx, %{name: name}, _meta) do
@@ -4821,6 +4936,20 @@ defmodule Gong.BDD.Instructions.V1 do
     end
 
     Map.put(ctx, :e2e_provider, provider)
+  end
+
+  defp e2e_tape_record_turn!(ctx, args, _meta) do
+    prompt = args.prompt
+    reply = Map.get(ctx, :last_reply, "")
+    store = ctx.tape_store
+    anchor = Map.get(ctx, :tape_last_anchor, "session-start")
+
+    # 追加 user entry
+    {:ok, store} = Gong.Tape.Store.append(store, anchor, %{kind: :user, content: prompt, metadata: %{}})
+    # 追加 assistant entry
+    {:ok, store} = Gong.Tape.Store.append(store, anchor, %{kind: :assistant, content: reply, metadata: %{}})
+
+    Map.put(ctx, :tape_store, store)
   end
 
   defp agent_chat_continue!(ctx, %{prompt: prompt}, _meta) do


### PR DESCRIPTION
## Summary
- 新增 6 个 CLI session BDD 场景（CLI-SESSION-005~010）：多会话排序、覆盖保存、双角色验证、损坏 JSON 容错、往返一致性、多轮 history
- 新增 1 个 E2E 场景（BDD-E2E-SESSION-001）：Deepseek 真实对话 → tape → session 保存恢复完整链路
- 新增 2 个 BDD 指令：`create_corrupt_session_file` + `e2e_tape_record_turn`
- 包含 Step3 基础实现：SessionCmd + Session.State

## Test plan
- [x] `mix test --only session` — 10/10 全过
- [x] `mix test --include e2e` — 21 个 e2e 测试全过（含新增 session e2e）
- [x] `mix test` — 724 测试，仅 3 个 Step4 桩失败（预期内）

🤖 Generated with [Claude Code](https://claude.com/claude-code)