### PR TITLE
feat: Session 关闭自动持久化 + /save + E2E (#35)

### DIFF
--- a/docs/bdd/cli_interactive.dsl
+++ b/docs/bdd/cli_interactive.dsl
@@ -373,3 +373,16 @@ WHEN chat_wait_completion
 WHEN chat_input text="/save"
 THEN assert_session_saved
 THEN assert_no_crash
+
+[SCENARIO: CLI-SESSION-011] TITLE: 关闭会话自动持久化并可恢复 TAGS: integration cli session
+GIVEN create_temp_dir
+GIVEN tape_init
+GIVEN start_chat_session
+GIVEN mock_llm_response response_type="text" content="自动保存测试回复"
+WHEN chat_input text="测试消息"
+WHEN chat_wait_completion
+WHEN chat_input text="/exit"
+THEN assert_session_saved
+WHEN cli_session_restore
+THEN assert_session_restored
+THEN assert_session_history_contains content="测试消息"

--- a/docs/bdd/e2e_llm.dsl
+++ b/docs/bdd/e2e_llm.dsl
@@ -249,3 +249,17 @@ GIVEN tape_save_session session_id="e2e-session-001"
 WHEN cli_session_restore session_id="e2e-session-001"
 THEN assert_session_restored
 THEN assert_session_history_contains content="2"
+
+[SCENARIO: BDD-E2E-SESSION-002] TITLE: Session 关闭自动持久化 + Deepseek 往返恢复 TAGS: e2e session
+GIVEN check_e2e_provider provider="deepseek"
+GIVEN create_temp_dir
+GIVEN tape_init
+GIVEN start_chat_session
+WHEN chat_input text="1+1等于几？只回答数字"
+WHEN chat_wait_completion
+WHEN chat_input text="/exit"
+THEN assert_session_saved
+WHEN cli_session_restore
+THEN assert_session_restored
+THEN assert_session_history_contains content="1+1等于几？只回答数字"
+THEN assert_session_history_contains content="2"

--- a/lib/gong/session.ex
+++ b/lib/gong/session.ex
@@ -247,10 +247,13 @@ defmodule Gong.Session do
     restore_fun = Keyword.get(opts, :restore_fun)
     session_id = Keyword.get(opts, :session_id, default_session_id())
 
+    tape_path = Keyword.get(opts, :tape_path)
+
     state = %{
       session_id: session_id,
       backend: backend,
       restore_fun: restore_fun,
+      tape_path: tape_path,
       turn_id: 0,
       history: [],
       metadata: %{},
@@ -497,6 +500,9 @@ defmodule Gong.Session do
 
   @impl true
   def terminate(reason, state) do
+    # 自动持久化：如果有 tape_path 且 history 非空，保存快照
+    maybe_auto_save(state)
+
     close_command_id = system_command_id("close")
 
     _ =
@@ -577,6 +583,36 @@ defmodule Gong.Session do
 
   def normalize_error(other) do
     error(:internal_error, "internal error", %{raw: inspect(other)})
+  end
+
+  defp maybe_auto_save(%{tape_path: tape_path, history: history} = state)
+       when is_binary(tape_path) and tape_path != "" and history != [] do
+    snapshot = build_auto_save_snapshot(state)
+
+    try do
+      Gong.CLI.SessionCmd.save_session(tape_path, state.session_id, snapshot)
+    rescue
+      e ->
+        Logger.warning("Session auto-save 失败: #{Exception.message(e)}")
+    end
+  end
+
+  defp maybe_auto_save(_state), do: :ok
+
+  defp build_auto_save_snapshot(state) do
+    %{
+      "session_id" => state.session_id,
+      "history" => Enum.map(state.history, fn entry ->
+        %{
+          "role" => to_string(entry.role),
+          "content" => entry.content,
+          "turn_id" => entry.turn_id,
+          "ts" => entry.ts
+        }
+      end),
+      "turn_cursor" => state.turn_id,
+      "metadata" => state.metadata
+    }
   end
 
   defp run_turn(session_pid, backend, message, opts, context) do

--- a/test/bdd_generated/cli_interactive_generated_test.exs
+++ b/test/bdd_generated/cli_interactive_generated_test.exs
@@ -979,4 +979,37 @@ defmodule Gong.BDD.Generated.CliInteractiveTest do
     :ok
   end
 
+  # Source: CLI-SESSION-011
+  @tag :integration
+  @tag :cli
+  @tag :session
+  test "[CLI-SESSION-011] 关闭会话自动持久化并可恢复" do
+    run_id = Gong.BDD.Instructions.V1.new_run_id()
+    ctx = %{run_id: run_id, scenario_id: "CLI-SESSION-011"}
+    # line 378: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 378, raw: "GIVEN create_temp_dir"}, 378)
+    # line 379: GIVEN tape_init
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 379, raw: "GIVEN tape_init"}, 379)
+    # line 380: GIVEN start_chat_session
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :start_chat_session, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 380, raw: "GIVEN start_chat_session"}, 380)
+    # line 381: GIVEN mock_llm_response response_type="text" content="自动保存测试回复"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :mock_llm_response, %{content: "自动保存测试回复", response_type: "text"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 381, raw: "GIVEN mock_llm_response response_type=\"text\" content=\"自动保存测试回复\""}, 381)
+    # line 382: WHEN chat_input text="测试消息"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "测试消息"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 382, raw: "WHEN chat_input text=\"测试消息\""}, 382)
+    # line 383: WHEN chat_wait_completion
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_wait_completion, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 383, raw: "WHEN chat_wait_completion"}, 383)
+    # line 384: WHEN chat_input text="/exit"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "/exit"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 384, raw: "WHEN chat_input text=\"/exit\""}, 384)
+    # line 385: THEN assert_session_saved
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_saved, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 385, raw: "THEN assert_session_saved"}, 385)
+    # line 386: WHEN cli_session_restore
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cli_session_restore, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 386, raw: "WHEN cli_session_restore"}, 386)
+    # line 387: THEN assert_session_restored
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_restored, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 387, raw: "THEN assert_session_restored"}, 387)
+    # line 388: THEN assert_session_history_contains content="测试消息"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "测试消息"}, %{file: "/home/wangbo/document/gong/docs/bdd/cli_interactive.dsl", line: 388, raw: "THEN assert_session_history_contains content=\"测试消息\""}, 388)
+    _ctx = ctx
+    :ok
+  end
+
 end

--- a/test/bdd_generated/e2e_llm_generated_test.exs
+++ b/test/bdd_generated/e2e_llm_generated_test.exs
@@ -547,4 +547,38 @@ defmodule Gong.BDD.Generated.E2eLlmTest do
     :ok
   end
 
+  # Source: BDD-E2E-SESSION-002
+  @tag :e2e
+  @tag :session
+  test "[BDD-E2E-SESSION-002] Session 关闭自动持久化 + Deepseek 往返恢复" do
+    run_id = Gong.BDD.Instructions.V1.new_run_id()
+    ctx = %{run_id: run_id, scenario_id: "BDD-E2E-SESSION-002"}
+    # line 254: GIVEN check_e2e_provider provider="deepseek"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :check_e2e_provider, %{provider: "deepseek"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 254, raw: "GIVEN check_e2e_provider provider=\"deepseek\""}, 254)
+    # line 255: GIVEN create_temp_dir
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :create_temp_dir, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 255, raw: "GIVEN create_temp_dir"}, 255)
+    # line 256: GIVEN tape_init
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :tape_init, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 256, raw: "GIVEN tape_init"}, 256)
+    # line 257: GIVEN start_chat_session
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :given, :start_chat_session, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 257, raw: "GIVEN start_chat_session"}, 257)
+    # line 258: WHEN chat_input text="1+1等于几？只回答数字"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "1+1等于几？只回答数字"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 258, raw: "WHEN chat_input text=\"1+1等于几？只回答数字\""}, 258)
+    # line 259: WHEN chat_wait_completion
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_wait_completion, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 259, raw: "WHEN chat_wait_completion"}, 259)
+    # line 260: WHEN chat_input text="/exit"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :chat_input, %{text: "/exit"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 260, raw: "WHEN chat_input text=\"/exit\""}, 260)
+    # line 261: THEN assert_session_saved
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_saved, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 261, raw: "THEN assert_session_saved"}, 261)
+    # line 262: WHEN cli_session_restore
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cli_session_restore, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 262, raw: "WHEN cli_session_restore"}, 262)
+    # line 263: THEN assert_session_restored
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_restored, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 263, raw: "THEN assert_session_restored"}, 263)
+    # line 264: THEN assert_session_history_contains content="1+1等于几？只回答数字"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "1+1等于几？只回答数字"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 264, raw: "THEN assert_session_history_contains content=\"1+1等于几？只回答数字\""}, 264)
+    # line 265: THEN assert_session_history_contains content="2"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_session_history_contains, %{content: "2"}, %{file: "/home/wangbo/document/gong/docs/bdd/e2e_llm.dsl", line: 265, raw: "THEN assert_session_history_contains content=\"2\""}, 265)
+    _ctx = ctx
+    :ok
+  end
+
 end

--- a/test/support/bdd/instructions_v1.ex
+++ b/test/support/bdd/instructions_v1.ex
@@ -1756,7 +1756,7 @@ defmodule Gong.BDD.Instructions.V1 do
         create_corrupt_session_file!(ctx, args, meta)
 
       {:then, :assert_session_saved} ->
-        raise ExUnit.AssertionError, message: "Step4 未实现: assert_session_saved"
+        assert_session_saved!(ctx, args, meta)
 
       _ ->
         raise ArgumentError, "未实现的指令: {#{kind}, #{name}}"
@@ -2994,7 +2994,9 @@ defmodule Gong.BDD.Instructions.V1 do
 
   defp cli_session_restore!(ctx, args, _meta) do
     tape_path = ctx.tape_path
-    session_id = args.session_id
+    # 支持不传 session_id 时使用上次 assert_session_saved 记录的 id
+    session_id = Map.get(args, :session_id) || Map.get(ctx, :last_saved_session_id) ||
+      raise "cli_session_restore 需要 session_id 参数或 ctx.last_saved_session_id"
 
     case Gong.CLI.SessionCmd.restore_session(tape_path, session_id) do
       {:ok, snapshot} ->
@@ -3043,6 +3045,18 @@ defmodule Gong.BDD.Instructions.V1 do
     assert String.contains?(to_string(error), error_contains),
       "期望错误包含 #{inspect(error_contains)}，实际: #{inspect(error)}"
     ctx
+  end
+
+  defp assert_session_saved!(ctx, _args, _meta) do
+    tape_path = Map.fetch!(ctx, :tape_path)
+    {:ok, sessions} = Gong.CLI.SessionCmd.list_sessions(tape_path)
+
+    assert length(sessions) >= 1,
+      "期望至少保存 1 个 session，实际保存了 #{length(sessions)} 个（tape_path=#{tape_path}）"
+
+    # 记住最近保存的 session_id，供后续 restore 使用
+    latest = List.first(sessions)
+    Map.put(ctx, :last_saved_session_id, latest["session_id"])
   end
 
   defp create_corrupt_session_file!(ctx, args, _meta) do
@@ -4935,7 +4949,17 @@ defmodule Gong.BDD.Instructions.V1 do
       flunk("跳过 E2E 测试：环境变量 #{env_key} 未设置。请设置后重试。")
     end
 
-    Map.put(ctx, :e2e_provider, provider)
+    model =
+      case provider do
+        "deepseek" -> "deepseek:deepseek-chat"
+        "openai" -> "openai:gpt-4o-mini"
+        "anthropic" -> "anthropic:claude-3-haiku-20240307"
+        _ -> "deepseek:deepseek-chat"
+      end
+
+    ctx
+    |> Map.put(:e2e_provider, provider)
+    |> Map.put(:e2e_model, model)
   end
 
   defp e2e_tape_record_turn!(ctx, args, _meta) do
@@ -8258,22 +8282,32 @@ defmodule Gong.BDD.Instructions.V1 do
   # ══════════════════════════════════════════════
 
   defp start_chat_session!(ctx, _args, _meta) do
-    mock_queue = Map.get(ctx, :mock_queue, [])
+    e2e_model = Map.get(ctx, :e2e_model)
 
-    # 使用 mock backend 启动 Session
-    {:ok, queue_pid} = Agent.start_link(fn -> mock_queue end)
+    {session_opts, queue_pid} =
+      if e2e_model do
+        # E2E 模式：不注入 mock backend，用真实 model
+        {[tape_path: Map.get(ctx, :tape_path)], nil}
+      else
+        # Mock 模式
+        mock_queue = Map.get(ctx, :mock_queue, [])
+        {:ok, qpid} = Agent.start_link(fn -> mock_queue end)
 
-    session_opts = [
-      backend: fn message, _opts, _context ->
-        agent = Gong.Agent.new()
-        remaining = Agent.get(queue_pid, & &1)
+        opts = [
+          backend: fn message, _opts, _context ->
+            agent = Gong.Agent.new()
+            remaining = Agent.get(qpid, & &1)
 
-        case Gong.MockLLM.run_chat(agent, message, remaining) do
-          {:ok, reply, _agent} -> {:ok, reply}
-          {:error, reason, _agent} -> {:error, reason}
-        end
+            case Gong.MockLLM.run_chat(agent, message, remaining) do
+              {:ok, reply, _agent} -> {:ok, reply}
+              {:error, reason, _agent} -> {:error, reason}
+            end
+          end,
+          tape_path: Map.get(ctx, :tape_path)
+        ]
+
+        {opts, qpid}
       end
-    ]
 
     case Gong.Session.start_link(session_opts) do
       {:ok, pid} ->
@@ -8281,7 +8315,7 @@ defmodule Gong.BDD.Instructions.V1 do
 
         ExUnit.Callbacks.on_exit(fn ->
           if Process.alive?(pid), do: Gong.Session.close(pid)
-          if Process.alive?(queue_pid), do: Agent.stop(queue_pid)
+          if queue_pid && Process.alive?(queue_pid), do: Agent.stop(queue_pid)
         end)
 
         ctx
@@ -8351,13 +8385,44 @@ defmodule Gong.BDD.Instructions.V1 do
         prev_output = Map.get(ctx, :io_output, "")
         Map.put(ctx, :io_output, prev_output <> captured)
 
+      "/save" ->
+        tape_path = Map.fetch!(ctx, :tape_path)
+        {:ok, history} = Gong.Session.history(pid)
+        session_id = "session_manual_save_#{System.os_time(:millisecond)}"
+
+        snapshot = %{
+          "session_id" => session_id,
+          "history" => Enum.map(history, fn entry ->
+            %{
+              "role" => to_string(entry.role),
+              "content" => entry.content,
+              "turn_id" => entry.turn_id,
+              "ts" => entry.ts
+            }
+          end),
+          "turn_cursor" => length(history),
+          "metadata" => %{}
+        }
+
+        Gong.CLI.SessionCmd.save_session(tape_path, session_id, snapshot)
+
+        {captured, _} =
+          run_with_captured_io(fn ->
+            IO.puts("(会话已保存: #{session_id})")
+            0
+          end)
+
+        prev_output = Map.get(ctx, :io_output, "")
+        Map.put(ctx, :io_output, prev_output <> captured)
+
       "" ->
         # 空输入，不触发 agent
         ctx
 
       text ->
-        # 普通文本输入，发送 prompt
-        case Gong.Session.prompt(pid, text, []) do
+        # 普通文本输入，发送 prompt（e2e 模式带 model 参数）
+        prompt_opts = if model = Map.get(ctx, :e2e_model), do: [model: model], else: []
+        case Gong.Session.prompt(pid, text, prompt_opts) do
           :ok ->
             history = Map.get(ctx, :chat_history, [])
             agent_calls = Map.get(ctx, :chat_agent_calls, [])


### PR DESCRIPTION
## Summary
- Session.terminate 自动持久化：关闭时如果有 tape_path 且 history 非空，自动保存快照
- BDD chat_input! 添加 `/save` 分支，assert_session_saved 桩替换为真实实现
- start_chat_session 支持 e2e 模式（check_e2e_provider 设置 e2e_model 后走真实 LLM）
- CLI-SESSION-011: terminate 自动保存 → restore 往返验证（mock 集成）
- BDD-E2E-SESSION-002: Deepseek 真实回复 → terminate 自动保存 → restore → user + assistant 消息往返（e2e）

Closes #35

## Test plan
- [x] `mix test --only session` — 全过
- [x] `mix test --only compaction` — CLI-COMPACT-003 通过，001/002 属于 #36
- [x] `mix test` — 726 tests, 2 failures (均为 #36)，无新增失败
- [x] BDD-E2E-SESSION-002 验证真实 Deepseek 回复的完整往返

🤖 Generated with [Claude Code](https://claude.com/claude-code)