### PR TITLE
fix(cli): tools 传参修复 + 编译警告消除

### DIFF
--- a/lib/gong/agent_loop.ex
+++ b/lib/gong/agent_loop.ex
@@ -8,6 +8,8 @@ defmodule Gong.AgentLoop do
   MockLLM 和 LiveLLM 变为薄包装，只需提供各自的 llm_backend 实现。
   """
 
+  Module.register_attribute(__MODULE__, :bdd_instruction, accumulate: true)
+
   alias Gong.Stream
   alias Gong.Stream.Event, as: StreamEvent
   alias Jido.Agent.Strategy.State, as: StratState
@@ -508,10 +510,14 @@ defmodule Gong.AgentLoop do
 
     llm_backend = fn agent, _call_id ->
       state = StratState.get(agent, %{})
+      config = state[:config] || %{}
+      reqllm_tools = config[:reqllm_tools] || []
       conversation = Map.get(state, :conversation, [])
       messages = format_conversation_for_reqllm(conversation)
 
-      case ReqLLM.generate_text(model_str, messages, receive_timeout: 60_000) do
+      opts = [tools: reqllm_tools, receive_timeout: 60_000]
+
+      case ReqLLM.generate_text(model_str, messages, opts) do
         {:ok, response} -> {:ok, parse_reqllm_response(response)}
         {:error, reason} -> {:ok, {:error, to_string(reason)}}
       end

--- a/lib/gong/cli.ex
+++ b/lib/gong/cli.ex
@@ -31,8 +31,13 @@ defmodule Gong.CLI do
 
   @spec main([String.t()]) :: no_return()
   def main(argv) when is_list(argv) do
+    opts = [
+      entry: System.get_env("GONG_ENTRY"),
+      legacy_entry: System.get_env("GONG_LEGACY_ENTRY") == "1"
+    ]
+
     argv
-    |> run()
+    |> run(opts)
     |> System.halt()
   end
 

--- a/lib/gong/model_registry.ex
+++ b/lib/gong/model_registry.ex
@@ -5,6 +5,8 @@ defmodule Gong.ModelRegistry do
   注册多个 LLM provider/model 组合，运行时动态切换当前活跃模型。
   """
 
+  Module.register_attribute(__MODULE__, :bdd_instruction, accumulate: true)
+
   @table :gong_model_registry
   @current_key :__current_model__
   @default_model_name :default

--- a/lib/gong/session.ex
+++ b/lib/gong/session.ex
@@ -13,6 +13,8 @@ defmodule Gong.Session do
   - `close/1`
   """
 
+  Module.register_attribute(__MODULE__, :bdd_instruction, accumulate: true)
+
   use GenServer
 
   alias Gong.AgentLoop


### PR DESCRIPTION
## Summary
- **#41 fix**: `run_as_backend` 的 llm_backend 闭包现在从 agent strategy state 读取 `reqllm_tools` 传给 `ReqLLM.generate_text`，LLM 能正确调用工具
- **#43 fix**: `@bdd_instruction` 模块属性注册为 `accumulate` 模式，消除 3 个文件的编译警告
- **CLI main/1**: escript 入口从环境变量读取 `legacy_entry`/`entry`，与 `bin/gong` 脚本行为一致
- **#42 blocked**: escript 启动优化因 tzdata 依赖不兼容 escript 模式而暂缓

## Test plan
- [x] 全量回归 736 tests, 0 failures
- [x] `mix compile` 零 @bdd_instruction 警告
- [ ] 手动验证 `bin/gong chat` 中 LLM 能调用工具

Closes #41
Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)