### PR TITLE
fix(bdd): 修复 BDD Smoke 门禁编译失败

### DIFF
--- a/lib/gong/bdd/instruction_registries/step2_cli.ex
+++ b/lib/gong/bdd/instruction_registries/step2_cli.ex
@@ -180,10 +180,16 @@ defmodule Gong.BDD.InstructionRegistries.Step2CLI do
       cli_session_restore: %{
         name: :cli_session_restore, kind: :when,
         args: %{
-          session_id: %{type: :string, required?: true, allowed: nil}
+          session_id: %{type: :string, required?: false, allowed: nil}
         },
         outputs: %{}, rules: [], boundary: :service,
         scopes: [:unit, :integration, :e2e], async?: false, eventually?: false, assert_class: nil
+      },
+      chat_session_restore: %{
+        name: :chat_session_restore, kind: :when,
+        args: %{},
+        outputs: %{}, rules: [], boundary: :service,
+        scopes: [:integration, :e2e], async?: false, eventually?: false, assert_class: nil
       },
       tape_save_session: %{
         name: :tape_save_session, kind: :given,


### PR DESCRIPTION
## Summary

- `cli_session_restore` 的 `session_id` 参数从 `required?: true` 改为 `required?: false`，不传时运行时 fallback 到 `ctx.last_saved_session_id`
- 新增 `chat_session_restore` 指令注册（运行时实现已有但未注册）

## Test plan

- [x] `bddc compile --in docs/bdd/cli_interactive.dsl` 编译通过
- [x] `mix test --exclude e2e` → 745 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)