### PR TITLE
fix: cwd 贯穿 Session → AgentLoop → Tools 全链路

### DIFF
--- a/bin/gong
+++ b/bin/gong
@@ -9,7 +9,7 @@ done
 ROOT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")/.." && pwd)"
 WORK_DIR="${PWD}"
 
-export GONG_WORKDIR="${WORK_DIR}"
+export GONG_WORKDIR="${GONG_WORKDIR:-${WORK_DIR}}"
 export GONG_ENTRY="${GONG_ENTRY:-bin/gong}"
 
 legacy_entry_migration_cmd() {

--- a/lib/gong/agent_loop.ex
+++ b/lib/gong/agent_loop.ex
@@ -263,10 +263,11 @@ defmodule Gong.AgentLoop do
     config = state[:config] || %{}
     actions_by_name = config[:actions_by_name] || %{}
 
-    # 合并工具上下文
+    # 合并工具上下文（注入 workspace）
     base_ctx = config[:base_tool_context] || %{}
     run_ctx = state[:run_tool_context] || %{}
-    tool_context = Map.merge(base_ctx, run_ctx)
+    workspace = Keyword.get(opts, :workspace, ".")
+    tool_context = Map.merge(base_ctx, run_ctx) |> Map.put(:workspace, workspace)
 
     # Steering 配置
     steering_config = Keyword.get(opts, :steering_config)

--- a/lib/gong/cli/chat.ex
+++ b/lib/gong/cli/chat.ex
@@ -26,7 +26,7 @@ defmodule Gong.CLI.Chat do
     Gong.Settings.init(cwd)
 
     tape_path = Path.join(cwd, ".gong/tape")
-    session_opts = build_session_opts(opts) |> Keyword.put(:tape_path, tape_path)
+    session_opts = build_session_opts(opts) |> Keyword.put(:tape_path, tape_path) |> Keyword.put(:workspace, cwd)
 
     case Session.start_link(session_opts) do
       {:ok, pid} ->

--- a/lib/gong/cli/run.ex
+++ b/lib/gong/cli/run.ex
@@ -25,7 +25,7 @@ defmodule Gong.CLI.Run do
     cwd = Keyword.get(opts, :cwd, File.cwd!())
     Gong.Settings.init(cwd)
 
-    session_opts = build_session_opts(opts)
+    session_opts = build_session_opts(opts) |> Keyword.put(:workspace, cwd)
 
     case Session.start_link(session_opts) do
       {:ok, pid} ->

--- a/lib/gong/session.ex
+++ b/lib/gong/session.ex
@@ -299,6 +299,7 @@ defmodule Gong.Session do
 
     tape_path = Keyword.get(opts, :tape_path)
     auto_compaction = Keyword.get(opts, :auto_compaction)
+    workspace = Keyword.get(opts, :workspace, File.cwd!())
 
     # Agent 路径：model（生产）/ agent+llm_backend_fn（测试直传）/ model+llm_backend_fn（测试覆盖）
     direct_agent = Keyword.get(opts, :agent)
@@ -351,6 +352,7 @@ defmodule Gong.Session do
       restore_fun: restore_fun,
       tape_path: tape_path,
       auto_compaction: auto_compaction,
+      workspace: workspace,
       turn_id: 0,
       metadata: init_metadata,
       subscribers: MapSet.new(),
@@ -1056,8 +1058,9 @@ defmodule Gong.Session do
   end
 
   # Agent 直调路径：调用 AgentLoop.run，从进程字典读取 usage
-  defp run_agent_turn(session_pid, agent, message, llm_backend_fn, command_id, turn_id) do
-    case AgentLoop.run(agent, message, llm_backend: llm_backend_fn) do
+  defp run_agent_turn(session_pid, agent, message, llm_backend_fn, command_id, turn_id, opts \\ []) do
+    agent_opts = [llm_backend: llm_backend_fn] ++ opts
+    case AgentLoop.run(agent, message, agent_opts) do
       {:ok, _reply, updated_agent} ->
         usage = Process.get(:gong_turn_usage, %{input_tokens: 0, output_tokens: 0})
         send(session_pid, {:session_turn_done, command_id, turn_id, {:ok_agent, updated_agent, usage}})
@@ -1075,6 +1078,7 @@ defmodule Gong.Session do
   defp start_agent_task(state, {message, command_id, turn_id}, session_pid) do
     agent = state.agent
     llm_backend_fn = state.llm_backend_fn
+    workspace = state.workspace
 
     Task.start(fn ->
       Gong.AgentLoop.set_stream_callback(fn event ->
@@ -1083,7 +1087,7 @@ defmodule Gong.Session do
         send(session_pid, {:session_stream_event, command_id, turn_id, event})
       end)
 
-      run_agent_turn(session_pid, agent, message, llm_backend_fn, command_id, turn_id)
+      run_agent_turn(session_pid, agent, message, llm_backend_fn, command_id, turn_id, workspace: workspace)
     end)
 
     %{state | agent_busy: true}

--- a/lib/gong/tools/bash.ex
+++ b/lib/gong/tools/bash.ex
@@ -20,9 +20,10 @@ defmodule Gong.Tools.Bash do
   @max_buffer_bytes 102_400
 
   @impl true
-  def run(params, _context) do
+  def run(params, context) do
+    workspace = Map.get(context, :workspace)
     with :ok <- validate_command(params.command),
-         {:ok, cwd} <- resolve_cwd(params[:cwd]) do
+         {:ok, cwd} <- resolve_cwd(params[:cwd] || workspace) do
       execute(params.command, params[:timeout] || 120, cwd)
     end
   end


### PR DESCRIPTION
## Summary

- CLI 的 `--cwd` / `GONG_WORKDIR` / `File.cwd!()` 解析出的 workspace 现在从 Chat/Run 一路透传到 Session → AgentLoop → tool_context → Bash 工具
- `bin/gong` 脚本修复 `GONG_WORKDIR` 被无条件覆盖的问题
- Bash 工具默认 cwd 回退到 workspace，LLM 未指定 cwd 时自动使用用户工作目录

## 改动文件

| 文件 | 改动 |
|---|---|
| `bin/gong` | `GONG_WORKDIR` 改用 `${GONG_WORKDIR:-$PWD}` |
| `lib/gong/cli/chat.ex` | session_opts 追加 `:workspace` |
| `lib/gong/cli/run.ex` | 同上 |
| `lib/gong/session.ex` | init 存 workspace，透传到 AgentLoop |
| `lib/gong/agent_loop.ex` | tool_context 注入 workspace |
| `lib/gong/tools/bash.ex` | 默认 cwd 回退 context.workspace |

## Test plan

- [x] `cd /var/tmp && bin/gong run "pwd"` → `/var/tmp`
- [x] `bin/gong run "pwd" --cwd /tmp` → `/tmp`
- [x] `GONG_WORKDIR=/var/tmp bin/gong run "pwd"` → `/var/tmp`
- [x] `mix test` 无新增失败
- [x] prod release 构建通过并实测

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)