### PR TITLE
fix(cli): Renderer 从 event.error 提取错误信息

### DIFF
--- a/lib/gong/cli/renderer.ex
+++ b/lib/gong/cli/renderer.ex
@@ -139,10 +139,12 @@ defmodule Gong.CLI.Renderer do
     IO.puts("#{@cyan}✓ #{truncate(result_str, @max_result_length)}#{@reset}")
   end
 
-  def render(%Events{type: type, payload: payload}) when type in ["error.stream", "error.runtime"] do
+  def render(%Events{type: type, payload: payload, error: error}) when type in ["error.stream", "error.runtime"] do
     message =
       Map.get(payload, :message) || Map.get(payload, "message") ||
-        get_in_error(payload) || "未知错误"
+        get_in_error(payload) ||
+        extract_error_message(error) ||
+        "未知错误"
 
     IO.puts(:stderr, "#{@red}✗ #{message}#{@reset}")
   end
@@ -167,6 +169,12 @@ defmodule Gong.CLI.Renderer do
     error = Map.get(payload, :error) || Map.get(payload, "error")
     if is_map(error), do: Map.get(error, :message) || Map.get(error, "message")
   end
+
+  defp extract_error_message(nil), do: nil
+  defp extract_error_message(error) when is_map(error) do
+    Map.get(error, :message) || Map.get(error, "message")
+  end
+  defp extract_error_message(_), do: nil
 
   @doc "截断字符串到指定最大长度"
   @spec truncate(String.t(), non_neg_integer()) :: String.t()

--- a/test/gong/cli/renderer_test.exs
+++ b/test/gong/cli/renderer_test.exs
@@ -112,6 +112,18 @@ defmodule Gong.CLI.RendererTest do
       output = capture_io(:stderr, fn -> Renderer.render(event) end)
       assert output =~ "✗"
     end
+
+    test "error.runtime payload 为空时从 event.error 提取 message" do
+      event = %{make_event("error.runtime", %{}) | error: %{code: :network_error, message: "LLM 调用失败"}}
+      output = capture_io(:stderr, fn -> Renderer.render(event) end)
+      assert output =~ "LLM 调用失败"
+    end
+
+    test "error.runtime payload 和 error 都无 message 时显示未知错误" do
+      event = make_event("error.runtime", %{})
+      output = capture_io(:stderr, fn -> Renderer.render(event) end)
+      assert output =~ "未知错误"
+    end
   end
 
   describe "truncate/2" do


### PR DESCRIPTION
## Summary

- Renderer 渲染 `error.runtime` / `error.stream` 事件时，之前只从 `event.payload` 提取 message，但 `Session.emit_runtime_error` 的 payload 为空 map，实际错误信息在 `event.error` 字段
- 新增 `extract_error_message/1` 作为 fallback 读取 `event.error.message`
- 新增 2 个测试覆盖 error envelope 和全空 fallback 场景

## Test plan

- [x] `mix test test/gong/cli/renderer_test.exs` — 13 tests, 0 failures
- [x] 新增测试：payload 为空时从 event.error 提取 message
- [x] 新增测试：payload 和 error 都无 message 时 fallback 为「未知错误」

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)