### PR TITLE
feat: 可配置迭代次数上限 (#69)

### DIFF
--- a/docs/bdd/settings.dsl
+++ b/docs/bdd/settings.dsl
@@ -42,12 +42,12 @@ WHEN list_settings
 THEN assert_settings_list contains="model"
 THEN assert_settings_list contains="temperature"
 
-[SCENARIO: SETTINGS-006] TITLE: cleanup 清除 ETS 表 TAGS: unit settings
+[SCENARIO: SETTINGS-006] TITLE: cleanup 后回退到编译期默认值 TAGS: unit settings
 GIVEN create_temp_dir
 GIVEN init_settings
 WHEN cleanup_settings
 WHEN get_setting_safe key="model"
-THEN assert_setting_nil
+THEN assert_setting_value expected="deepseek:deepseek-chat"
 
 [SCENARIO: SETTINGS-007] TITLE: 畸形 JSON 配置文件不崩溃 TAGS: unit settings
 GIVEN create_temp_dir

--- a/lib/gong/agent_loop.ex
+++ b/lib/gong/agent_loop.ex
@@ -27,7 +27,7 @@ defmodule Gong.AgentLoop do
       - :llm_backend — `fn agent, call_id -> {:ok, response} | {:error, reason}` 闭包，
         每次需要 LLM 响应时调用。response 格式同 MockLLM 的 {:text, _} | {:tool_calls, _} | {:error, _}
       - :hooks — Hook 模块列表，默认 []
-      - :max_turns — 最大轮数，默认 25
+      - :max_turns — 最大轮数，默认从设置读取，支持 :infinity
       - :steering_config — Steering 配置（可选）
 
   ## 返回
@@ -116,7 +116,11 @@ defmodule Gong.AgentLoop do
     {agent, directives} = ReAct.cmd(agent, [start_instruction], %{})
     call_id = extract_call_id(directives)
 
-    max_turns = Keyword.get(opts, :max_turns, 25)
+    max_turns = 
+      case Keyword.get(opts, :max_turns, :from_settings) do
+        :from_settings -> Gong.Settings.get_integer("max_iterations", 25)
+        value -> value
+      end
 
     # 驱动 ReAct 循环
     drive_loop(agent, call_id, llm_backend, hooks, opts, 0, max_turns)
@@ -124,9 +128,10 @@ defmodule Gong.AgentLoop do
 
   # ── 循环驱动 ──
 
+  # :infinity 时 guard 不匹配，永不触发迭代限制
   defp drive_loop(agent, _call_id, _llm_backend, _hooks, _opts, turn, max_turns)
-       when turn >= max_turns do
-    {:error, "达到最大迭代次数 #{max_turns}", agent}
+       when is_integer(max_turns) and turn >= max_turns do
+    {:error, {:iteration_limit_reached, %{max_iterations: max_turns, current_turn: turn}}, agent}
   end
 
   defp drive_loop(agent, call_id, llm_backend, hooks, opts, turn, max_turns) do

--- a/lib/gong/session.ex
+++ b/lib/gong/session.ex
@@ -737,6 +737,17 @@ defmodule Gong.Session do
   def normalize_error(:cancelled), do: error(:cancelled, "cancelled", %{})
   def normalize_error(:unauthorized), do: error(:unauthorized, "unauthorized", %{})
 
+  def normalize_error({:iteration_limit_reached, details}) when is_map(details) do
+    max = Map.get(details, :max_iterations, "?")
+    %{
+      code: :iteration_limit_reached,
+      message: "达到最大迭代次数 #{max}",
+      retriable: false,
+      retry_after: nil,
+      details: details
+    }
+  end
+
   def normalize_error(other) do
     error(:internal_error, "internal error", %{raw: inspect(other)})
   end
@@ -1058,7 +1069,7 @@ defmodule Gong.Session do
   end
 
   # Agent 直调路径：调用 AgentLoop.run，从进程字典读取 usage
-  defp run_agent_turn(session_pid, agent, message, llm_backend_fn, command_id, turn_id, opts \\ []) do
+  defp run_agent_turn(session_pid, agent, message, llm_backend_fn, command_id, turn_id, opts) do
     agent_opts = [llm_backend: llm_backend_fn] ++ opts
     case AgentLoop.run(agent, message, agent_opts) do
       {:ok, _reply, updated_agent} ->
@@ -1772,6 +1783,7 @@ defmodule Gong.Session do
          timeout
          cancelled
          unauthorized
+         iteration_limit_reached
        )a,
     do: code
 

--- a/lib/gong/settings.ex
+++ b/lib/gong/settings.ex
@@ -11,7 +11,8 @@ defmodule Gong.Settings do
   @default_settings %{
     "model" => "deepseek:deepseek-chat",
     "max_tokens" => "8192",
-    "temperature" => "0.7"
+    "temperature" => "0.7",
+    "max_iterations" => "25"
   }
 
   @doc "初始化设置管理器"
@@ -40,9 +41,28 @@ defmodule Gong.Settings do
   @doc "获取设置值"
   @spec get(String.t()) :: term()
   def get(key) do
-    case :ets.lookup(@table, key) do
-      [{^key, value}] -> value
-      [] -> Map.get(@default_settings, key)
+    if :ets.info(@table) == :undefined do
+      Map.get(@default_settings, key)
+    else
+      case :ets.lookup(@table, key) do
+        [{^key, value}] -> value
+        [] -> Map.get(@default_settings, key)
+      end
+    end
+  end
+
+  @doc "获取整数值设置，支持 :infinity 特殊值"
+  @spec get_integer(String.t(), integer() | :infinity) :: integer() | :infinity
+  def get_integer(key, default) do
+    case get(key) do
+      "infinity" -> :infinity
+      value when is_binary(value) ->
+        case Integer.parse(value) do
+          {int, ""} -> int
+          _ -> default
+        end
+      value when is_integer(value) -> value
+      _ -> default
     end
   end
 

--- a/test/bdd_generated/settings_generated_test.exs
+++ b/test/bdd_generated/settings_generated_test.exs
@@ -115,8 +115,8 @@ defmodule Gong.BDD.Generated.SettingsTest do
     ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :cleanup_settings, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/settings.dsl", line: 48, raw: "WHEN cleanup_settings"}, 48)
     # line 49: WHEN get_setting_safe key="model"
     ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :when, :get_setting_safe, %{key: "model"}, %{file: "/home/wangbo/document/gong/docs/bdd/settings.dsl", line: 49, raw: "WHEN get_setting_safe key=\"model\""}, 49)
-    # line 50: THEN assert_setting_nil
-    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_setting_nil, %{}, %{file: "/home/wangbo/document/gong/docs/bdd/settings.dsl", line: 50, raw: "THEN assert_setting_nil"}, 50)
+    # line 50: THEN assert_setting_value expected="deepseek:deepseek-chat"
+    ctx = Gong.BDD.Instructions.V1.run_step!(ctx, :then, :assert_setting_value, %{expected: "deepseek:deepseek-chat"}, %{file: "/home/wangbo/document/gong/docs/bdd/settings.dsl", line: 50, raw: "THEN assert_setting_value expected=\"deepseek:deepseek-chat\""}, 50)
     _ctx = ctx
     :ok
   end

--- a/test/gong/agent_loop_test.exs
+++ b/test/gong/agent_loop_test.exs
@@ -89,7 +89,57 @@ defmodule Gong.AgentLoopTest do
           {:tool_calls, tool_calls}
         ])
 
-      assert {:error, "达到最大迭代次数 2", _agent} =
+      assert {:error, {:iteration_limit_reached, %{max_iterations: 2, current_turn: 2}}, _agent} =
+               Gong.AgentLoop.run(agent, "无限循环",
+                 llm_backend: backend,
+                 max_turns: 2
+               )
+
+      Agent.stop(pid)
+    end
+
+    test "从 Settings 读取 max_iterations 默认值", %{agent: agent} do
+      # 初始化 Settings 并设置较小的 max_iterations
+      tmp = System.tmp_dir!()
+      Gong.Settings.init(tmp)
+      Gong.Settings.set("max_iterations", "3")
+
+      tool_calls = [%{name: "list_directory", arguments: %{"path" => "/tmp"}}]
+
+      {backend, pid} =
+        queue_backend([
+          {:tool_calls, tool_calls},
+          {:tool_calls, tool_calls},
+          {:tool_calls, tool_calls},
+          {:tool_calls, tool_calls},
+          {:tool_calls, tool_calls}
+        ])
+
+      # 不传 max_turns，应从 Settings 读取 max_iterations=3
+      assert {:error, {:iteration_limit_reached, %{max_iterations: 3, current_turn: 3}}, _agent} =
+               Gong.AgentLoop.run(agent, "无限循环", llm_backend: backend)
+
+      Agent.stop(pid)
+    end
+
+    test "max_turns 参数优先于 Settings", %{agent: agent} do
+      tmp = System.tmp_dir!()
+      Gong.Settings.init(tmp)
+      Gong.Settings.set("max_iterations", "10")
+
+      tool_calls = [%{name: "list_directory", arguments: %{"path" => "/tmp"}}]
+
+      {backend, pid} =
+        queue_backend([
+          {:tool_calls, tool_calls},
+          {:tool_calls, tool_calls},
+          {:tool_calls, tool_calls},
+          {:tool_calls, tool_calls},
+          {:tool_calls, tool_calls}
+        ])
+
+      # 显式传 max_turns=2 应覆盖 Settings 的 max_iterations=10
+      assert {:error, {:iteration_limit_reached, %{max_iterations: 2, current_turn: 2}}, _agent} =
                Gong.AgentLoop.run(agent, "无限循环",
                  llm_backend: backend,
                  max_turns: 2


### PR DESCRIPTION
## Summary
- AgentLoop 支持从 `Settings.max_iterations` 读取迭代上限（默认 25），`max_turns` 参数可覆盖
- 超限返回结构化错误 `{:iteration_limit_reached, %{max_iterations: N, current_turn: N}}`
- `Settings.get/1` 在 ETS 表不存在时安全回退到编译期默认值（修复测试环境崩溃）
- `Settings.get_integer/2` 新增，支持 `"infinity"` → `:infinity`

## Test plan
- [x] `mix test test/gong/agent_loop_test.exs` — 19 tests, 0 failures
- [x] `mix test` — 832 tests, 2 failures（预先存在，非本次引入）
- [x] `mix compile --warnings-as-errors` 无 warning

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)