### PR TITLE
feat: 工具参数友好显示 (#72)

### DIFF
--- a/lib/gong/cli/renderer.ex
+++ b/lib/gong/cli/renderer.ex
@@ -116,13 +116,7 @@ defmodule Gong.CLI.Renderer do
   def render(%Events{type: "tool.start", payload: payload}) do
     tool_name = Map.get(payload, :tool_name) || Map.get(payload, "tool_name") || "unknown"
     tool_args = Map.get(payload, :tool_args) || Map.get(payload, "tool_args") || %{}
-
-    args_str =
-      case tool_args do
-        s when is_binary(s) -> s
-        m when is_map(m) -> Jason.encode!(m)
-        other -> inspect(other)
-      end
+    args_str = Gong.CLI.ToolDisplay.format(tool_name, tool_args)
 
     IO.puts("#{@yellow}⚡ #{tool_name}#{@reset} #{@faint}#{truncate(args_str, @max_tool_args_length)}#{@reset}")
   end

--- a/lib/gong/cli/tool_display.ex
+++ b/lib/gong/cli/tool_display.ex
@@ -1,0 +1,25 @@
+defmodule Gong.CLI.ToolDisplay do
+  @moduledoc "工具参数友好显示 — 按约定参数名自动提取关键信息"
+
+  # 按优先级排列：优先显示 file_path，其次 command，再 pattern/path
+  @display_keys ~w(file_path command pattern path)a
+
+  @spec format(String.t() | atom(), term()) :: String.t()
+  def format(_tool_name, args) when is_map(args) and map_size(args) == 0, do: ""
+
+  def format(_tool_name, args) when is_map(args) do
+    case find_display_value(args) do
+      nil -> Jason.encode!(args)
+      val -> to_string(val)
+    end
+  end
+
+  def format(_tool_name, args) when is_binary(args), do: args
+  def format(_tool_name, args), do: inspect(args)
+
+  defp find_display_value(args) do
+    Enum.find_value(@display_keys, fn key ->
+      Map.get(args, key) || Map.get(args, Atom.to_string(key))
+    end)
+  end
+end

--- a/test/gong/cli/tool_display_test.exs
+++ b/test/gong/cli/tool_display_test.exs
@@ -1,0 +1,56 @@
+defmodule Gong.CLI.ToolDisplayTest do
+  use ExUnit.Case, async: true
+
+  alias Gong.CLI.ToolDisplay
+
+  describe "format/2 — 按约定参数名自动提取" do
+    test "file_path 类工具显示路径" do
+      assert ToolDisplay.format("read_file", %{file_path: "/a/b.ex"}) == "/a/b.ex"
+      assert ToolDisplay.format("write_file", %{file_path: "/tmp/out.txt"}) == "/tmp/out.txt"
+      assert ToolDisplay.format("edit_file", %{file_path: "/src/main.ex", old_string: "foo"}) == "/src/main.ex"
+    end
+
+    test "bash 显示命令" do
+      assert ToolDisplay.format("bash", %{command: "ls -la"}) == "ls -la"
+      assert ToolDisplay.format("bash", %{command: "mix test", timeout: 120}) == "mix test"
+    end
+
+    test "grep 显示 pattern（优先于 path）" do
+      assert ToolDisplay.format("grep", %{pattern: "foo", path: "/src"}) == "foo"
+    end
+
+    test "path 参数" do
+      assert ToolDisplay.format("list_directory", %{path: "/tmp"}) == "/tmp"
+    end
+
+    test "file_path 优先于 command 和 path" do
+      assert ToolDisplay.format("tool", %{file_path: "/a.ex", command: "ls", path: "/b"}) == "/a.ex"
+    end
+  end
+
+  describe "format/2 — string key 兼容" do
+    test "string key 也能提取" do
+      assert ToolDisplay.format("read_file", %{"file_path" => "/a/b.ex"}) == "/a/b.ex"
+      assert ToolDisplay.format("bash", %{"command" => "ls -la"}) == "ls -la"
+    end
+  end
+
+  describe "format/2 — fallback" do
+    test "无约定参数名 → JSON" do
+      assert ToolDisplay.format("custom", %{foo: "bar"}) == ~s({"foo":"bar"})
+    end
+
+    test "空 map → 空字符串" do
+      assert ToolDisplay.format("tool", %{}) == ""
+    end
+
+    test "字符串参数原样返回" do
+      assert ToolDisplay.format("tool", "raw string") == "raw string"
+    end
+
+    test "其他类型 → inspect" do
+      assert ToolDisplay.format("tool", 42) == "42"
+      assert ToolDisplay.format("tool", [:a, :b]) == "[:a, :b]"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- 新增 `Gong.CLI.ToolDisplay` 模块，按约定参数名（file_path/command/pattern/path）自动提取关键信息
- Renderer 即时格式化，不改 Events struct，不污染 tape 序列化
- 10 个单元测试覆盖 atom key、string key、fallback、边界情况

## Test plan
- [x] `mix test test/gong/cli/tool_display_test.exs test/gong/cli/renderer_test.exs` — 23 tests, 0 failures
- [x] `mix compile` 无新增 warning

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)