### PR TITLE
fix: sub(#82): HeaderProfile 层（default/opencode） (#84)

### DIFF
--- a/lib/gong/header_profile.ex
+++ b/lib/gong/header_profile.ex
@@ -1,0 +1,30 @@
+defmodule Gong.HeaderProfile do
+  @moduledoc """
+  请求头策略层。
+
+  根据 profile 原子返回预定义的 headers map，
+  作为 LLMRouter 合并链中的最低优先级基底。
+  """
+
+  @type profile :: :default | :opencode
+
+  @doc """
+  根据 profile 返回对应的 headers map。
+
+  - `:default` — 不注入额外头，返回空 map
+  - `:opencode` — 注入最小稳定指纹头集合
+  - 未知 profile — 静默回退到 `:default`
+  """
+  @spec resolve(profile()) :: map()
+  def resolve(:default), do: %{}
+
+  def resolve(:opencode) do
+    %{
+      "User-Agent" => "OpenCode/1.0",
+      "X-Client-Name" => "opencode",
+      "Accept" => "application/json"
+    }
+  end
+
+  def resolve(_unknown), do: resolve(:default)
+end

--- a/lib/gong/llm_router.ex
+++ b/lib/gong/llm_router.ex
@@ -7,6 +7,7 @@ defmodule Gong.LLMRouter do
   通过 ProviderRegistry 获取运行时策略后委托 ReqLLM 执行。
   """
 
+  alias Gong.HeaderProfile
   alias Gong.ProviderRegistry
 
   @default_timeout 60_000
@@ -69,8 +70,14 @@ defmodule Gong.LLMRouter do
     final_base_url = runtime_base_url || model_base_url || provider_base_url
     final_timeout = runtime_timeout || provider_timeout || @default_timeout
 
+    # profile 级 headers（最低优先级基底）
+    header_profile = Map.get(model_config, :header_profile, :default)
+    profile_headers = HeaderProfile.resolve(header_profile)
+
+    # 合并：runtime > model > provider > profile
     final_headers =
-      (provider_headers || %{})
+      profile_headers
+      |> Map.merge(provider_headers || %{})
       |> Map.merge(model_headers || %{})
       |> Map.merge(runtime_headers || %{})
 

--- a/test/gong/header_profile_test.exs
+++ b/test/gong/header_profile_test.exs
@@ -1,0 +1,26 @@
+defmodule Gong.HeaderProfileTest do
+  use ExUnit.Case, async: true
+
+  alias Gong.HeaderProfile
+
+  describe "resolve/1" do
+    test "default 返回空 map" do
+      assert HeaderProfile.resolve(:default) == %{}
+    end
+
+    test "opencode 返回三个指纹头" do
+      headers = HeaderProfile.resolve(:opencode)
+
+      assert headers == %{
+               "User-Agent" => "OpenCode/1.0",
+               "X-Client-Name" => "opencode",
+               "Accept" => "application/json"
+             }
+    end
+
+    test "未知 profile 回退到 default" do
+      assert HeaderProfile.resolve(:unknown) == %{}
+      assert HeaderProfile.resolve(:foobar) == %{}
+    end
+  end
+end

--- a/test/gong/integration/provider_routing_test.exs
+++ b/test/gong/integration/provider_routing_test.exs
@@ -181,6 +181,67 @@ defmodule Gong.Integration.ProviderRoutingTest do
     end
   end
 
+  # ── header_profile 端到端合并测试 ──
+
+  describe "header_profile 三层合并" do
+    test "profile + provider + model 三层合并优先级正确" do
+      ProviderRegistry.register(
+        "hp_test",
+        Gong.Test.MockProvider,
+        %{headers: %{"X-Provider" => "pv", "Accept" => "text/plain"}},
+        priority: 10,
+        timeout: 60_000
+      )
+
+      model_config = %{
+        provider: "hp_test",
+        model_id: "test-model",
+        header_profile: :opencode,
+        headers: %{"X-Model" => "mv"}
+      }
+
+      resolved = LLMRouter.resolve_config(model_config)
+
+      # profile 基底
+      assert resolved.headers["User-Agent"] == "OpenCode/1.0"
+      assert resolved.headers["X-Client-Name"] == "opencode"
+      # provider 覆盖 profile 的 Accept
+      assert resolved.headers["Accept"] == "text/plain"
+      # provider 独有头保留
+      assert resolved.headers["X-Provider"] == "pv"
+      # model 独有头保留
+      assert resolved.headers["X-Model"] == "mv"
+    end
+
+    test "profile + provider + model + runtime 四层合并" do
+      ProviderRegistry.register(
+        "hp_full",
+        Gong.Test.MockProvider,
+        %{headers: %{"X-Provider" => "pv"}},
+        priority: 10,
+        timeout: 60_000
+      )
+
+      model_config = %{
+        provider: "hp_full",
+        model_id: "test-model",
+        header_profile: :opencode,
+        headers: %{"Accept" => "text/html"}
+      }
+
+      resolved = LLMRouter.resolve_config(model_config, headers: %{"User-Agent" => "RuntimeUA"})
+
+      # runtime 覆盖 profile 的 User-Agent
+      assert resolved.headers["User-Agent"] == "RuntimeUA"
+      # model 覆盖 profile 的 Accept
+      assert resolved.headers["Accept"] == "text/html"
+      # profile 独有头保留
+      assert resolved.headers["X-Client-Name"] == "opencode"
+      # provider 独有头保留
+      assert resolved.headers["X-Provider"] == "pv"
+    end
+  end
+
   # ── AgentLoop 与 Compaction 使用同一 Router 断言 ──
 
   describe "AgentLoop 与 Summarizer 统一路由" do

--- a/test/gong/llm_router_test.exs
+++ b/test/gong/llm_router_test.exs
@@ -114,6 +114,49 @@ defmodule Gong.LLMRouterTest do
     end
   end
 
+  # ── header_profile 注入测试 ──
+
+  describe "header_profile 注入" do
+    test "无 header_profile 字段时行为不变" do
+      model_config = %{provider: "deepseek", model_id: "deepseek-chat"}
+      resolved = LLMRouter.resolve_config(model_config)
+
+      assert resolved.headers == %{}
+    end
+
+    test "header_profile: :opencode 注入指纹头" do
+      model_config = %{provider: "deepseek", model_id: "deepseek-chat", header_profile: :opencode}
+      resolved = LLMRouter.resolve_config(model_config)
+
+      assert resolved.headers["User-Agent"] == "OpenCode/1.0"
+      assert resolved.headers["X-Client-Name"] == "opencode"
+      assert resolved.headers["Accept"] == "application/json"
+    end
+
+    test "model headers 与 profile headers 同名时 model 优先覆盖" do
+      model_config = %{
+        provider: "deepseek",
+        model_id: "deepseek-chat",
+        header_profile: :opencode,
+        headers: %{"User-Agent" => "CustomAgent"}
+      }
+
+      resolved = LLMRouter.resolve_config(model_config)
+
+      assert resolved.headers["User-Agent"] == "CustomAgent"
+      # profile 的其他头仍保留
+      assert resolved.headers["X-Client-Name"] == "opencode"
+      assert resolved.headers["Accept"] == "application/json"
+    end
+
+    test "header_profile: :default 不注入额外头" do
+      model_config = %{provider: "deepseek", model_id: "deepseek-chat", header_profile: :default}
+      resolved = LLMRouter.resolve_config(model_config)
+
+      assert resolved.headers == %{}
+    end
+  end
+
   # ── fallback 触发测试 ──
 
   describe "fallback 逻辑" do


### PR DESCRIPTION
Closes #84

## Summary

## ✅ 最终方案：HeaderProfile 请求头策略层（default/opencode）

### 实现方案

新增 HeaderProfile 纯函数模块，通过 resolve/1 根据 profile 原子返回 headers map。在 LLMRouter.resolve_config/2 中注入 profile headers 作为最低优先级基底，合并链变为 profile < provider < model。不修改 ModelRegistry，header_profile 字段缺省回落在 LLMRouter 层处理（Map.get(model_config, :header_profile, :default)）。opencode profile 使用最小稳定指纹头集合（User-Agent/X-Client-Name/Accept 三个字段），未知 profile 静默回退到 default。

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `lib/gong/header_profile.ex` | create | 新建 HeaderProfile 模块。定义 @type profile :: :default | :opencode。实现 resolve/1 纯函数：:default 返回 %{}，:opencode 返回 %{"User-Agent" => "OpenCode/1.0", "X-Client-Name" => "opencode", "Accept" => "application/json"}，其他值回退 :default。 |
| `lib/gong/llm_router.ex` | modify | 在 resolve_config/2 的 final_headers 合并逻辑处（约第70行），改为三层合并：header_profile = Map.get(model_config, :header_profile, :default); profile_headers = HeaderProfile.resolve(header_profile); final_headers = profile_headers |> Map.merge(provider_headers || %{}) |> Map.merge(model_headers || %{})。新增 alias Gong.HeaderProfile。 |
| `test/gong/header_profile_test.exs` | create | HeaderProfile 单元测试。覆盖 default 返回空 map、opencode 返回三个指纹头、未知 profile 回退 default 三个场景。 |
| `test/gong/llm_router_test.exs` | modify | 新增 describe "header_profile 注入" 块，验证：1) 无 header_profile 字段时行为不变；2) header_profile: :opencode 注入指纹头；3) model headers 与 profile headers 同名时 model 优先覆盖。 |
| `test/gong/integration/provider_routing_test.exs` | modify | 新增端到端测试：注册带 headers 的 provider + 设置 header_profile: :opencode 的 model_config，验证三层合并后 final_headers 正确反映优先级。 |

### 测试场景

1. **header_profile=default 不注入额外头**: 输入 `model_config = %{provider: "deepseek", model_id: "deepseek-chat", header_profile: :default}` → 预期 `resolve_config 返回 headers 仅包含 provider + model 自身 headers，无额外注入`
2. **header_profile=opencode 注入指纹头**: 输入 `model_config = %{provider: "deepseek", model_id: "deepseek-chat", header_profile: :opencode}` → 预期 `resolve_config 返回 headers 包含 User-Agent=OpenCode/1.0, X-Client-Name=opencode, Accept=application/json`
3. **model headers 与 profile headers 同名时 model 优先**: 输入 `model_config = %{provider: "deepseek", model_id: "deepseek-chat", header_profile: :opencode, headers: %{"User-Agent" => "CustomAgent"}}` → 预期 `final_headers["User-Agent"] == "CustomAgent"（model 覆盖 profile）`
4. **未配置 header_profile 时默认 :default**: 输入 `model_config = %{provider: "deepseek", model_id: "deepseek-chat"}（无 header_profile 字段）` → 预期 `行为与显式 header_profile: :default 完全一致，不注入额外头`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":"lib/gong/header_profile.ex","action":"create","description":"新建 HeaderProfile 模块。定义 @type profile :: :default | :opencode。实现 resolve/1 纯函数：:default 返回 %{}，:opencode 返回 %{\"User-Agent\" =\u003e \"OpenCode/1.0\", \"X-Client-Name\" =\u003e \"opencode\", \"Accept\" =\u003e \"application/json\"}，其他值回退 :default。"},{"path":"lib/gong/llm_router.ex","action":"modify","description":"在 resolve_config/2 的 final_headers 合并逻辑处（约第70行），改为三层合并：header_profile = Map.get(model_config, :header_profile, :default); profile_headers = HeaderProfile.resolve(header_profile); final_headers = profile_headers |\u003e Map.merge(provider_headers || %{}) |\u003e Map.merge(model_headers || %{})。新增 alias Gong.HeaderProfile。"},{"path":"test/gong/header_profile_test.exs","action":"create","description":"HeaderProfile 单元测试。覆盖 default 返回空 map、opencode 返回三个指纹头、未知 profile 回退 default 三个场景。"},{"path":"test/gong/llm_router_test.exs","action":"modify","description":"新增 describe \"header_profile 注入\" 块，验证：1) 无 header_profile 字段时行为不变；2) header_profile: :opencode 注入指纹头；3) model headers 与 profile headers 同名时 model 优先覆盖。"},{"path":"test/gong/integration/provider_routing_test.exs","action":"modify","description":"新增端到端测试：注册带 headers 的 provider + 设置 header_profile: :opencode 的 model_config，验证三层合并后 final_headers 正确反映优先级。"}] -->