### PR TITLE
fix: sub(#82): 模型配置迁移与多模型回归（Kimi/MiniMax/GLM） (#86)

### DIFF
--- a/docs/model-migration.md
+++ b/docs/model-migration.md
@@ -1,0 +1,76 @@
+# 模型配置迁移说明
+
+## auth_mode 字段
+
+`auth_mode` 是 `ModelRegistry.model_config` 新增的可选字段，用于指定模型的 API 鉴权方式。
+
+| 值 | 含义 | 注入的 Header |
+|---|---|---|
+| `:bearer` | OpenAI 兼容鉴权 | `authorization: Bearer <key>` |
+| `:anthropic_header` | Anthropic 兼容鉴权 | `x-api-key: <key>` |
+| 未设置 | 不注入鉴权头（由下游 ReqLLM.Provider 处理） | 无 |
+
+**重要**：DeepSeek 等已有模型不设置 `auth_mode`，鉴权由 `ReqLLM.Provider` 模块处理，行为与改造前完全一致。
+
+## 新增模型配置
+
+### Kimi (Moonshot)
+
+```elixir
+Gong.ModelRegistry.register(:kimi, %{
+  provider: "kimi",
+  model_id: "moonshot-v1-auto",
+  base_url: "https://api.moonshot.cn",
+  api_key_env: "KIMI_API_KEY",
+  auth_mode: :anthropic_header
+})
+```
+
+环境变量：`KIMI_API_KEY`
+
+### MiniMax
+
+```elixir
+Gong.ModelRegistry.register(:minimax, %{
+  provider: "minimax",
+  model_id: "minimax-text-01",
+  base_url: "https://api.minimax.chat",
+  api_key_env: "MINIMAX_API_KEY",
+  auth_mode: :anthropic_header
+})
+```
+
+环境变量：`MINIMAX_API_KEY`
+
+### GLM (智谱)
+
+```elixir
+Gong.ModelRegistry.register(:glm, %{
+  provider: "glm",
+  model_id: "glm-4",
+  base_url: "https://open.bigmodel.cn/api/paas/v4",
+  api_key_env: "GLM_API_KEY",
+  auth_mode: :bearer
+})
+```
+
+环境变量：`GLM_API_KEY`
+
+## 环境变量要求
+
+使用新模型前，需在部署环境中配置对应的 API Key 环境变量：
+
+```bash
+export KIMI_API_KEY="your-kimi-api-key"
+export MINIMAX_API_KEY="your-minimax-api-key"
+export GLM_API_KEY="your-glm-api-key"
+```
+
+如果环境变量未设置，`resolve_config` 不会抛异常，但 headers 中不会包含鉴权头，API 调用将因鉴权失败而报错。
+
+## 回滚步骤
+
+1. 从 `application.ex` 中移除三个 `ModelRegistry.register` 调用
+2. 从 `llm_router.ex` 中移除 `inject_auth_header/2` 函数及其调用
+3. 从 `model_registry.ex` 中移除 `auth_mode` 类型定义和 `apply_defaults` 中的默认值
+4. DeepSeek 行为完全不受影响，无需额外操作

--- a/lib/gong/application.ex
+++ b/lib/gong/application.ex
@@ -26,6 +26,31 @@ defmodule Gong.Application do
     Gong.PromptTemplate.init()
     Gong.ModelRegistry.init()
 
+    # 注册 Kimi/MiniMax/GLM 模型配置
+    Gong.ModelRegistry.register(:kimi, %{
+      provider: "kimi",
+      model_id: "moonshot-v1-auto",
+      base_url: "https://api.moonshot.cn",
+      api_key_env: "KIMI_API_KEY",
+      auth_mode: :anthropic_header
+    })
+
+    Gong.ModelRegistry.register(:minimax, %{
+      provider: "minimax",
+      model_id: "minimax-text-01",
+      base_url: "https://api.minimax.chat",
+      api_key_env: "MINIMAX_API_KEY",
+      auth_mode: :anthropic_header
+    })
+
+    Gong.ModelRegistry.register(:glm, %{
+      provider: "glm",
+      model_id: "glm-4",
+      base_url: "https://open.bigmodel.cn/api/paas/v4",
+      api_key_env: "GLM_API_KEY",
+      auth_mode: :bearer
+    })
+
     # 初始化 Provider 注册表
     Gong.ProviderRegistry.init()
 

--- a/lib/gong/llm_router.ex
+++ b/lib/gong/llm_router.ex
@@ -81,6 +81,9 @@ defmodule Gong.LLMRouter do
       |> Map.merge(model_headers || %{})
       |> Map.merge(runtime_headers || %{})
 
+    # auth_mode 鉴权头注入：仅当 model_config 显式声明 auth_mode 时才注入
+    final_headers = inject_auth_header(final_headers, model_config)
+
     model_str = "#{provider_name}:#{Map.get(model_config, :model_id, "deepseek-chat")}"
 
     %{
@@ -155,4 +158,26 @@ defmodule Gong.LLMRouter do
   defp maybe_put_headers(opts, nil), do: opts
   defp maybe_put_headers(opts, headers) when headers == %{}, do: opts
   defp maybe_put_headers(opts, headers), do: Keyword.put(opts, :headers, headers)
+
+  # 根据 auth_mode 注入鉴权头，仅当 model_config 显式包含 auth_mode 字段时生效
+  defp inject_auth_header(headers, %{auth_mode: auth_mode, api_key_env: env_var})
+       when is_atom(auth_mode) and is_binary(env_var) do
+    case System.get_env(env_var) do
+      nil ->
+        headers
+
+      api_key ->
+        case auth_mode do
+          :anthropic_header ->
+            # 不覆盖已有的 x-api-key
+            Map.put_new(headers, "x-api-key", api_key)
+
+          :bearer ->
+            # 不覆盖已有的 authorization
+            Map.put_new(headers, "authorization", "Bearer #{api_key}")
+        end
+    end
+  end
+
+  defp inject_auth_header(headers, _model_config), do: headers
 end

--- a/lib/gong/model_registry.ex
+++ b/lib/gong/model_registry.ex
@@ -11,11 +11,14 @@ defmodule Gong.ModelRegistry do
   @current_key :__current_model__
   @default_model_name :default
 
+  @type auth_mode :: :bearer | :anthropic_header
+
   @type model_config :: %{
           provider: String.t(),
           model_id: String.t(),
           api_key_env: String.t(),
-          context_window: non_neg_integer() | nil
+          context_window: non_neg_integer() | nil,
+          auth_mode: auth_mode() | nil
         }
 
   # ── 初始化 ──
@@ -202,7 +205,7 @@ defmodule Gong.ModelRegistry do
   @spec apply_defaults(model_config()) :: model_config()
   def apply_defaults(config) when is_map(config) do
     Map.merge(
-      %{api_key_env: "", context_window: @default_context_window, base_url: nil, headers: %{}},
+      %{api_key_env: "", context_window: @default_context_window, base_url: nil, headers: %{}, auth_mode: :bearer},
       config
     )
   end

--- a/test/gong/integration/provider_routing_test.exs
+++ b/test/gong/integration/provider_routing_test.exs
@@ -345,6 +345,88 @@ defmodule Gong.Integration.ProviderRoutingTest do
     end
   end
 
+  # ── 多模型 auth_mode 路由 ──
+
+  describe "多模型 auth_mode 路由" do
+    setup do
+      Gong.ModelRegistry.init()
+
+      Gong.ModelRegistry.register(:kimi, %{
+        provider: "kimi",
+        model_id: "moonshot-v1-auto",
+        base_url: "https://api.moonshot.cn",
+        api_key_env: "KIMI_API_KEY",
+        auth_mode: :anthropic_header
+      })
+
+      Gong.ModelRegistry.register(:minimax, %{
+        provider: "minimax",
+        model_id: "minimax-text-01",
+        base_url: "https://api.minimax.chat",
+        api_key_env: "MINIMAX_API_KEY",
+        auth_mode: :anthropic_header
+      })
+
+      Gong.ModelRegistry.register(:glm, %{
+        provider: "glm",
+        model_id: "glm-4",
+        base_url: "https://open.bigmodel.cn/api/paas/v4",
+        api_key_env: "GLM_API_KEY",
+        auth_mode: :bearer
+      })
+
+      # 注册对应的 provider 以便 resolve_config 能获取 provider 配置
+      ProviderRegistry.register("kimi", Gong.Test.MockProvider, %{}, priority: 5, timeout: 60_000)
+      ProviderRegistry.register("minimax", Gong.Test.MockProvider, %{}, priority: 5, timeout: 60_000)
+      ProviderRegistry.register("glm", Gong.Test.MockProvider, %{}, priority: 5, timeout: 60_000)
+
+      on_exit(fn -> Gong.ModelRegistry.cleanup() end)
+      :ok
+    end
+
+    test "Kimi resolve_config 包含 x-api-key header 和正确 base_url" do
+      System.put_env("KIMI_API_KEY", "test123")
+      on_exit(fn -> System.delete_env("KIMI_API_KEY") end)
+
+      :ok = Gong.ModelRegistry.switch(:kimi)
+      {_name, kimi_config} = Gong.ModelRegistry.current_model()
+
+      resolved = LLMRouter.resolve_config(kimi_config)
+
+      assert resolved.headers["x-api-key"] == "test123"
+      assert resolved.base_url == "https://api.moonshot.cn"
+      assert resolved.model_str == "kimi:moonshot-v1-auto"
+    end
+
+    test "MiniMax resolve_config 包含 x-api-key header 和正确 base_url" do
+      System.put_env("MINIMAX_API_KEY", "test456")
+      on_exit(fn -> System.delete_env("MINIMAX_API_KEY") end)
+
+      :ok = Gong.ModelRegistry.switch(:minimax)
+      {_name, minimax_config} = Gong.ModelRegistry.current_model()
+
+      resolved = LLMRouter.resolve_config(minimax_config)
+
+      assert resolved.headers["x-api-key"] == "test456"
+      assert resolved.base_url == "https://api.minimax.chat"
+      assert resolved.model_str == "minimax:minimax-text-01"
+    end
+
+    test "GLM resolve_config 包含 Bearer header 和正确 base_url" do
+      System.put_env("GLM_API_KEY", "test789")
+      on_exit(fn -> System.delete_env("GLM_API_KEY") end)
+
+      :ok = Gong.ModelRegistry.switch(:glm)
+      {_name, glm_config} = Gong.ModelRegistry.current_model()
+
+      resolved = LLMRouter.resolve_config(glm_config)
+
+      assert resolved.headers["authorization"] == "Bearer test789"
+      assert resolved.base_url == "https://open.bigmodel.cn/api/paas/v4"
+      assert resolved.model_str == "glm:glm-4"
+    end
+  end
+
   # ── AgentLoop 与 Compaction 使用同一 Router 断言 ──
 
   describe "AgentLoop 与 Summarizer 统一路由" do

--- a/test/gong/llm_router_test.exs
+++ b/test/gong/llm_router_test.exs
@@ -157,6 +157,81 @@ defmodule Gong.LLMRouterTest do
     end
   end
 
+  # ── auth_mode 鉴权头注入测试 ──
+
+  describe "auth_mode 鉴权头注入" do
+    test "auth_mode: :anthropic_header 注入 x-api-key" do
+      System.put_env("TEST_ANTHRO_KEY", "anthro-key-123")
+      on_exit(fn -> System.delete_env("TEST_ANTHRO_KEY") end)
+
+      model_config = %{
+        provider: "deepseek",
+        model_id: "deepseek-chat",
+        api_key_env: "TEST_ANTHRO_KEY",
+        auth_mode: :anthropic_header
+      }
+
+      resolved = LLMRouter.resolve_config(model_config)
+      assert resolved.headers["x-api-key"] == "anthro-key-123"
+    end
+
+    test "auth_mode: :bearer 注入 Authorization: Bearer" do
+      System.put_env("TEST_BEARER_KEY", "bearer-key-456")
+      on_exit(fn -> System.delete_env("TEST_BEARER_KEY") end)
+
+      model_config = %{
+        provider: "deepseek",
+        model_id: "deepseek-chat",
+        api_key_env: "TEST_BEARER_KEY",
+        auth_mode: :bearer
+      }
+
+      resolved = LLMRouter.resolve_config(model_config)
+      assert resolved.headers["authorization"] == "Bearer bearer-key-456"
+    end
+
+    test "无 auth_mode 字段（默认）不注入额外 header" do
+      model_config = %{provider: "deepseek", model_id: "deepseek-chat"}
+      resolved = LLMRouter.resolve_config(model_config)
+
+      # DeepSeek 默认配置不应包含鉴权头（由 ReqLLM.Provider 处理）
+      refute Map.has_key?(resolved.headers, "x-api-key")
+      refute Map.has_key?(resolved.headers, "authorization")
+    end
+
+    test "已有自定义 header 不被 auth_mode 覆盖" do
+      System.put_env("TEST_NOCOVER_KEY", "should-not-appear")
+      on_exit(fn -> System.delete_env("TEST_NOCOVER_KEY") end)
+
+      model_config = %{
+        provider: "deepseek",
+        model_id: "deepseek-chat",
+        api_key_env: "TEST_NOCOVER_KEY",
+        auth_mode: :anthropic_header,
+        headers: %{"x-api-key" => "custom-key"}
+      }
+
+      resolved = LLMRouter.resolve_config(model_config)
+      # 已有的自定义 key 不应被覆盖
+      assert resolved.headers["x-api-key"] == "custom-key"
+    end
+
+    test "API key 环境变量缺失时不注入 header 也不抛异常" do
+      # 确保环境变量不存在
+      System.delete_env("NONEXISTENT_API_KEY")
+
+      model_config = %{
+        provider: "deepseek",
+        model_id: "deepseek-chat",
+        api_key_env: "NONEXISTENT_API_KEY",
+        auth_mode: :anthropic_header
+      }
+
+      resolved = LLMRouter.resolve_config(model_config)
+      refute Map.has_key?(resolved.headers, "x-api-key")
+    end
+  end
+
   # ── fallback 触发测试 ──
 
   describe "fallback 逻辑" do


### PR DESCRIPTION
## Summary

人工接管 #86，基于最新 `integration/main` 重新整理实现，避免回退 #84/#85 已合并内容。

- 保留并落地 #86 的模型迁移能力（Kimi / MiniMax / GLM）
- 保留并补全 auth_mode 相关路由与测试
- 新增模型迁移文档 `docs/model-migration.md`

## Test plan

- `mix compile --warnings-as-errors`
- `mix test test/gong/llm_router_test.exs test/gong/integration/provider_routing_test.exs test/gong/model_registry_test.exs`

Refs #86
