### PR TITLE
feat: chat 会话内模型热重载与 /model 命令 (#95)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,5 @@
+import Config
+
+# 关闭 tzdata 自动轮询更新，避免 CLI 会话中输出无关日志噪音。
+# 需要手动更新时可在运维流程中显式开启并执行更新。
+config :tzdata, :autoupdate, :disabled

--- a/lib/gong/agent_loop.ex
+++ b/lib/gong/agent_loop.ex
@@ -236,7 +236,6 @@ defmodule Gong.AgentLoop do
 
       :error ->
         error_msg = state[:result] || "unknown error"
-        emit_stream_event(StreamEvent.new(:error, content: error_msg))
         :telemetry.execute([:gong, :turn, :end], %{count: 1}, %{tool_calls: []})
         {:error, error_msg, agent}
 
@@ -579,13 +578,11 @@ defmodule Gong.AgentLoop do
               {:ok, parsed}
 
             {:error, reason} ->
-              # reason 可能是结构体（如 ReqLLM.Error.API.Request），不能直接 to_string
-              {:ok, {:error, inspect(reason)}}
+              {:ok, {:error, Gong.LLMRouter.humanize_error(reason)}}
           end
 
         {:error, reason} ->
-          # reason 可能是结构体（如 ReqLLM.Error.API.Request），不能直接 to_string
-          {:ok, {:error, inspect(reason)}}
+          {:ok, {:error, Gong.LLMRouter.humanize_error(reason)}}
       end
     end
   end

--- a/lib/gong/cli/chat.ex
+++ b/lib/gong/cli/chat.ex
@@ -7,6 +7,7 @@ defmodule Gong.CLI.Chat do
 
   alias Gong.Session
   alias Gong.CLI.Renderer
+  alias Gong.ModelRegistry
 
   @exit_ok 0
   @exit_error 1
@@ -26,7 +27,11 @@ defmodule Gong.CLI.Chat do
     Gong.Settings.init(cwd)
 
     tape_path = Path.join(cwd, ".gong/tape")
-    session_opts = build_session_opts(opts) |> Keyword.put(:tape_path, tape_path) |> Keyword.put(:workspace, cwd)
+    session_opts =
+      build_session_opts(opts)
+      |> Keyword.put(:tape_path, tape_path)
+      |> Keyword.put(:workspace, cwd)
+      |> Keyword.put(:model_sync, true)
 
     case Session.start_link(session_opts) do
       {:ok, pid} ->
@@ -104,6 +109,41 @@ defmodule Gong.CLI.Chat do
   defp handle_input("/help", session_pid) do
     IO.puts(help_text())
     repl_loop(session_pid)
+  end
+
+  defp handle_input("/models", session_pid) do
+    print_models(session_pid)
+    repl_loop(session_pid)
+  end
+
+  defp handle_input("/model", session_pid) do
+    IO.puts("用法: /model <name>")
+    repl_loop(session_pid)
+  end
+
+  defp handle_input("/model " <> model_name, session_pid) do
+    cwd = File.cwd!()
+    target = String.trim(model_name)
+
+    if target == "" do
+      IO.puts("用法: /model <name>")
+      repl_loop(session_pid)
+    else
+      case Gong.Settings.set_model(cwd, target) do
+        {:ok, %{short: short, model: full_model}} ->
+          _ = Session.sync_model(session_pid)
+          IO.puts("已切换模型: #{short} (#{full_model})")
+
+        {:error, :unknown_provider} ->
+          IO.puts("模型不存在: #{target}")
+          print_available_models_hint()
+
+        {:error, :persist_failed} ->
+          IO.puts("模型切换失败: 设置写入失败")
+      end
+
+      repl_loop(session_pid)
+    end
   end
 
   defp handle_input("/history", session_pid) do
@@ -227,6 +267,33 @@ defmodule Gong.CLI.Chat do
       /history  查看对话历史
       /clear    清空对话
       /save     保存当前会话
+      /models   查看可用模型
+      /model    切换模型（如 /model kimi）
     """
+  end
+
+  defp print_models(session_pid) do
+    current_model =
+      case Session.metadata(session_pid) do
+        {:ok, metadata} -> get_in(metadata, ["session", "model"]) || "unknown"
+        _ -> "unknown"
+      end
+
+    IO.puts("当前模型: #{current_model}")
+    IO.puts("可用模型:")
+
+    ModelRegistry.available_models()
+    |> Enum.each(fn item ->
+      IO.puts("  - #{item.short} -> #{item.model}")
+    end)
+  end
+
+  defp print_available_models_hint do
+    options =
+      ModelRegistry.available_models()
+      |> Enum.map(& &1.short)
+      |> Enum.join(", ")
+
+    IO.puts("可用模型: #{options}")
   end
 end

--- a/lib/gong/cli/chat.ex
+++ b/lib/gong/cli/chat.ex
@@ -118,6 +118,7 @@ defmodule Gong.CLI.Chat do
 
   defp handle_input("/model", session_pid) do
     IO.puts("用法: /model <name>")
+    print_models(session_pid)
     repl_loop(session_pid)
   end
 
@@ -127,6 +128,7 @@ defmodule Gong.CLI.Chat do
 
     if target == "" do
       IO.puts("用法: /model <name>")
+      print_models(session_pid)
       repl_loop(session_pid)
     else
       case Gong.Settings.set_model(cwd, target) do

--- a/lib/gong/cli/chat.ex
+++ b/lib/gong/cli/chat.ex
@@ -133,8 +133,17 @@ defmodule Gong.CLI.Chat do
     else
       case Gong.Settings.set_model(cwd, target) do
         {:ok, %{short: short, model: full_model}} ->
-          _ = Session.sync_model(session_pid)
-          IO.puts("已切换模型: #{short} (#{full_model})")
+          case Session.sync_model(session_pid) do
+            {:ok, %{changed: true}} ->
+              IO.puts("已切换模型: #{short} (#{full_model})")
+
+            {:ok, %{changed: false, reason: reason}} ->
+              current = current_model(session_pid)
+              IO.puts("设置已更新，但会话未切换（#{reason}），当前模型: #{current}")
+
+            {:error, error} ->
+              IO.puts("设置已更新，但会话同步失败: #{inspect(error)}")
+          end
 
         {:error, :unknown_provider} ->
           IO.puts("模型不存在: #{target}")
@@ -275,11 +284,7 @@ defmodule Gong.CLI.Chat do
   end
 
   defp print_models(session_pid) do
-    current_model =
-      case Session.metadata(session_pid) do
-        {:ok, metadata} -> get_in(metadata, ["session", "model"]) || "unknown"
-        _ -> "unknown"
-      end
+    current_model = current_model(session_pid)
 
     IO.puts("当前模型: #{current_model}")
     IO.puts("可用模型:")
@@ -297,5 +302,12 @@ defmodule Gong.CLI.Chat do
       |> Enum.join(", ")
 
     IO.puts("可用模型: #{options}")
+  end
+
+  defp current_model(session_pid) do
+    case Session.metadata(session_pid) do
+      {:ok, metadata} -> get_in(metadata, ["session", "model"]) || "unknown"
+      _ -> "unknown"
+    end
   end
 end

--- a/lib/gong/cli/renderer.ex
+++ b/lib/gong/cli/renderer.ex
@@ -146,12 +146,13 @@ defmodule Gong.CLI.Renderer do
   end
 
   def render(%Events{type: type, payload: payload, error: error}) when type in ["error.stream", "error.runtime"] do
-    message =
+    raw_message =
       Map.get(payload, :message) || Map.get(payload, "message") ||
         get_in_error(payload) ||
         extract_error_message(error) ||
         "未知错误"
 
+    message = normalize_error_message(raw_message)
     IO.puts(:stderr, "#{@red}✗ #{message}#{@reset}")
   end
 
@@ -289,6 +290,31 @@ defmodule Gong.CLI.Renderer do
     Map.get(error, :message) || Map.get(error, "message")
   end
   defp extract_error_message(_), do: nil
+
+  defp normalize_error_message(message) when not is_binary(message), do: to_string(message)
+  defp normalize_error_message(message) do
+    cond do
+      String.contains?(message, "ReqLLM.Error.API.Request") ->
+        extract_reqllm_request_message(message) || message
+
+      true ->
+        message
+    end
+  end
+
+  defp extract_reqllm_request_message(message) do
+    # 优先取 response_body.message，其次取 reason 字段
+    response_body_message =
+      Regex.run(~r/response_body:\s*%\{[^}]*"message"\s*=>\s*"([^"]+)"/, message, capture: :all_but_first)
+
+    reason_message =
+      Regex.run(~r/reason:\s*"([^"]+)"/, message, capture: :all_but_first)
+
+    case response_body_message || reason_message do
+      [detail] when is_binary(detail) -> detail
+      _ -> nil
+    end
+  end
 
   @doc "截断字符串到指定最大长度"
   @spec truncate(String.t(), non_neg_integer()) :: String.t()

--- a/lib/gong/llm_router.ex
+++ b/lib/gong/llm_router.ex
@@ -34,6 +34,25 @@ defmodule Gong.LLMRouter do
     call_with_fallback(model_config, messages, opts, :generate_text)
   end
 
+  @doc "将底层错误格式化为用户可读文案"
+  @spec humanize_error(term()) :: String.t()
+  def humanize_error(%{message: message}) when is_binary(message) and message != "", do: message
+
+  def humanize_error(%{response_body: body, status: status, reason: reason})
+      when is_map(body) and is_integer(status) do
+    detail = Map.get(body, :message) || Map.get(body, "message") || reason || "请求失败"
+    "#{detail} (HTTP #{status})"
+  end
+
+  def humanize_error(%{reason: reason, status: status})
+      when is_binary(reason) and is_integer(status) do
+    "#{reason} (HTTP #{status})"
+  end
+
+  def humanize_error(error) when is_binary(error), do: error
+  def humanize_error(error) when is_atom(error), do: to_string(error)
+  def humanize_error(error), do: inspect(error)
+
   @doc """
   按 runtime > model > provider > default 优先级合并配置。
 
@@ -95,8 +114,10 @@ defmodule Gong.LLMRouter do
         nil
       end
 
+    api_key_env = Map.get(model_config, :api_key_env) || Map.get(provider_config, :api_key_env)
+
     api_key =
-      case Map.get(model_config, :api_key_env) || Map.get(provider_config, :api_key_env) do
+      case api_key_env do
         env when is_binary(env) and env != "" -> System.get_env(env)
         _ -> nil
       end
@@ -108,6 +129,7 @@ defmodule Gong.LLMRouter do
       base_url: final_base_url,
       headers: final_headers,
       api_key: api_key,
+      api_key_env: api_key_env,
       receive_timeout: final_timeout,
       provider_name: provider_name
     }
@@ -124,13 +146,16 @@ defmodule Gong.LLMRouter do
 
     model_input = resolved.req_model_spec || resolved.model_str
 
-    case do_call(method, model_input, messages, final_opts) do
-      {:ok, _} = success ->
-        success
+    with :ok <- validate_api_key(resolved),
+         result <- do_call(method, model_input, messages, final_opts) do
+      case result do
+        {:ok, _} = success ->
+          success
 
-      {:error, reason} = _error ->
-        # 尝试 fallback chain
-        try_fallback(model_config, messages, opts, method, provider_name, reason)
+        {:error, reason} ->
+          # 尝试 fallback chain
+          try_fallback(model_config, messages, opts, method, provider_name, reason)
+      end
     end
   end
 
@@ -253,4 +278,16 @@ defmodule Gong.LLMRouter do
   end
 
   defp inject_auth_header(headers, _model_config), do: headers
+
+  defp validate_api_key(%{api_key_env: env_var, api_key: api_key})
+       when is_binary(env_var) and env_var != "" and (is_nil(api_key) or api_key == "") do
+    {:error,
+     %{
+       code: :unauthorized,
+       message: "缺少 #{env_var}，请先配置后重试",
+       details: %{api_key_env: env_var}
+     }}
+  end
+
+  defp validate_api_key(_resolved), do: :ok
 end

--- a/lib/gong/model_registry.ex
+++ b/lib/gong/model_registry.ex
@@ -123,6 +123,56 @@ defmodule Gong.ModelRegistry do
     |> Enum.sort_by(fn {name, _} -> name end)
   end
 
+  @doc """
+  解析为“已注册模型”，不会回退到动态构造配置。
+
+  用于 `/model` 等需要严格校验的场景：
+  - 输入短名（如 `kimi` / `k2p5`）
+  - 输入完整名（`provider:model_id`）
+  """
+  @spec resolve_registered_model(String.t()) ::
+          {:ok, %{name: atom(), short: String.t(), model: String.t(), config: model_config()}}
+          | {:error, :unknown_provider}
+  def resolve_registered_model(model_str) when is_binary(model_str) do
+    ensure_table!()
+    trimmed = String.trim(model_str)
+
+    cond do
+      trimmed == "" ->
+        {:error, :unknown_provider}
+
+      String.contains?(trimmed, ":") ->
+        resolve_by_provider_model(trimmed)
+
+      true ->
+        resolve_by_short_name(trimmed)
+    end
+  end
+
+  @doc "返回可切换模型列表（短名 + 完整名）"
+  @spec available_models() :: [%{name: atom(), short: String.t(), model: String.t(), config: model_config()}]
+  def available_models do
+    models =
+      list()
+      |> Enum.reject(fn {name, _} -> name == @default_model_name end)
+
+    selected =
+      if models == [] do
+        list()
+      else
+        models
+      end
+
+    Enum.map(selected, fn {name, config} ->
+      %{
+        name: name,
+        short: Atom.to_string(name),
+        model: model_to_string(config),
+        config: config
+      }
+    end)
+  end
+
   @doc "校验模型是否可用（API key 环境变量存在）"
   @spec validate(atom()) :: :ok | {:error, String.t()}
   def validate(name) when is_atom(name) do
@@ -222,6 +272,51 @@ defmodule Gong.ModelRegistry do
     end
   end
 
+  defp resolve_by_provider_model(model_str) do
+    case String.split(model_str, ":", parts: 2) do
+      [provider, model_id] when provider != "" and model_id != "" ->
+        resolved_provider = Gong.ProviderRegistry.resolve_alias(provider)
+
+        available_models()
+        |> Enum.find(fn item ->
+          config = item.config
+          (config.provider == provider or config.provider == resolved_provider) and
+            config.model_id == model_id
+        end)
+        |> case do
+          nil -> {:error, :unknown_provider}
+          found -> {:ok, found}
+        end
+
+      _ ->
+        {:error, :unknown_provider}
+    end
+  end
+
+  defp resolve_by_short_name(model_str) do
+    normalized = String.downcase(model_str)
+
+    case Map.get(@short_name_aliases, normalized) do
+      nil ->
+        {:error, :unknown_provider}
+
+      name ->
+        case :ets.lookup(@table, name) do
+          [{^name, config}] ->
+            {:ok,
+             %{
+               name: name,
+               short: Atom.to_string(name),
+               model: model_to_string(config),
+               config: config
+             }}
+
+          [] ->
+            {:error, :unknown_provider}
+        end
+    end
+  end
+
   defp find_by_provider_model(provider, model_id) do
     result =
       :ets.tab2list(@table)
@@ -313,4 +408,6 @@ defmodule Gong.ModelRegistry do
       init()
     end
   end
+
+  defp model_to_string(%{provider: provider, model_id: model_id}), do: "#{provider}:#{model_id}"
 end

--- a/lib/gong/prompt.ex
+++ b/lib/gong/prompt.ex
@@ -66,6 +66,8 @@ defmodule Gong.Prompt do
     workspace = Keyword.get(opts, :workspace, ".")
     context = Keyword.get(opts, :context, "")
     skills = Keyword.get(opts, :skills, "")
+    current_model = Keyword.get(opts, :current_model)
+    available_models = Keyword.get(opts, :available_models, [])
 
     now = DateTime.utc_now() |> DateTime.to_string()
 
@@ -73,6 +75,14 @@ defmodule Gong.Prompt do
       @default_prompt,
       if(context != "", do: "\n## Context\n#{context}\n", else: ""),
       if(skills != "", do: "\n## Skills\n#{skills}\n", else: ""),
+      if(is_binary(current_model),
+        do: "\n## Model\n当前模型：#{current_model}\n",
+        else: ""
+      ),
+      if(is_list(available_models) and available_models != [],
+        do: "可用模型：#{Enum.join(available_models, ", ")}\n",
+        else: ""
+      ),
       "\n当前时间：#{now}",
       "\n当前工作目录：#{workspace}\n"
     ]

--- a/lib/gong/session.ex
+++ b/lib/gong/session.ex
@@ -832,6 +832,8 @@ defmodule Gong.Session do
   def normalize_error(:timeout), do: error(:timeout, "timeout", %{})
   def normalize_error(:cancelled), do: error(:cancelled, "cancelled", %{})
   def normalize_error(:unauthorized), do: error(:unauthorized, "unauthorized", %{})
+  def normalize_error(other) when is_binary(other),
+    do: error(:internal_error, normalize_runtime_message(other), %{})
 
   def normalize_error({:iteration_limit_reached, details}) when is_map(details) do
     max = Map.get(details, :max_iterations, "?")
@@ -846,6 +848,18 @@ defmodule Gong.Session do
 
   def normalize_error(other) do
     error(:internal_error, "internal error", %{raw: inspect(other)})
+  end
+
+  defp normalize_runtime_message(message) when is_binary(message) do
+    cond do
+      String.starts_with?(message, "Error: \"") and String.ends_with?(message, "\"") ->
+        message
+        |> String.trim_leading("Error: \"")
+        |> String.trim_trailing("\"")
+
+      true ->
+        message
+    end
   end
 
   # 刷新活动时间戳并同步 ETS 索引

--- a/lib/gong/session.ex
+++ b/lib/gong/session.ex
@@ -20,6 +20,7 @@ defmodule Gong.Session do
   alias Gong.AgentLoop
   alias Gong.AutoCompaction
   alias Gong.ModelRegistry
+  alias Gong.Settings
   alias Gong.Session.Events
   alias Gong.Stream.Event, as: StreamEvent
   alias Gong.Thinking
@@ -220,6 +221,15 @@ defmodule Gong.Session do
     end
   end
 
+  @doc "同步当前会话模型（从 settings 读取）"
+  @spec sync_model(pid()) :: {:ok, map()} | {:error, error_t()}
+  def sync_model(pid) do
+    case safe_genserver_call(pid, :sync_model) do
+      {:ok, {:ok, _} = ok} -> ok
+      {:error, reason} -> {:error, normalize_error(reason)}
+    end
+  end
+
   @spec session_id(pid()) :: {:ok, String.t()} | {:error, error_t()}
   def session_id(pid) do
     safe_genserver_call(pid, :session_id)
@@ -313,6 +323,7 @@ defmodule Gong.Session do
     # Agent 路径：model（生产）/ agent+llm_backend_fn（测试直传）/ model+llm_backend_fn（测试覆盖）
     direct_agent = Keyword.get(opts, :agent)
     llm_backend_fn_override = Keyword.get(opts, :llm_backend_fn)
+    model_sync_opt = Keyword.get(opts, :model_sync, false)
 
     {agent, llm_backend_fn} =
       cond do
@@ -358,6 +369,8 @@ defmodule Gong.Session do
 
     now = System.monotonic_time(:millisecond)
     external_session_key = Keyword.get(opts, :external_session_key)
+    model_sync_enabled =
+      model_sync_opt and is_binary(model) and direct_agent == nil and llm_backend_fn_override == nil
 
     state = %{
       session_id: session_id,
@@ -367,6 +380,7 @@ defmodule Gong.Session do
       tape_path: tape_path,
       auto_compaction: auto_compaction,
       workspace: workspace,
+      model_sync_enabled: model_sync_enabled,
       turn_id: 0,
       metadata: init_metadata,
       subscribers: MapSet.new(),
@@ -450,6 +464,12 @@ defmodule Gong.Session do
     {:reply, state.metadata, state}
   end
 
+  def handle_call(:sync_model, _from, state) do
+    state = refresh_activity(state)
+    {new_state, sync_result} = maybe_sync_model_from_settings(state)
+    {:reply, {:ok, sync_result}, new_state}
+  end
+
   def handle_call(:session_id, _from, state) do
     {:reply, {:ok, state.session_id}, state}
   end
@@ -519,6 +539,7 @@ defmodule Gong.Session do
 
   def handle_call({:prompt, message, opts}, _from, state) do
     state = refresh_activity(state)
+    {state, _sync_result} = maybe_sync_model_from_settings(state)
 
     with :ok <- validate_prompt(message),
          :ok <- validate_prompt_opts(opts),
@@ -542,6 +563,8 @@ defmodule Gong.Session do
   end
 
   def handle_call({:submit_command, command_payload, opts}, _from, state) do
+    {state, _sync_result} = maybe_sync_model_from_settings(state)
+
     with :ok <- validate_prompt_opts(opts),
          {:ok, normalized_payload} <- validate_command_payload(command_payload, state),
          :ok <- validate_backend_available(state) do
@@ -1238,7 +1261,17 @@ defmodule Gong.Session do
         send(session_pid, {:session_stream_event, command_id, turn_id, event})
       end)
 
-      run_agent_turn(session_pid, agent, message, llm_backend_fn, command_id, turn_id, workspace: workspace)
+      run_agent_turn(
+        session_pid,
+        agent,
+        message,
+        llm_backend_fn,
+        command_id,
+        turn_id,
+        workspace: workspace,
+        current_model: current_model_for_prompt(state),
+        available_models: available_models_for_prompt()
+      )
     end)
 
     %{state | agent_busy: true}
@@ -1254,6 +1287,51 @@ defmodule Gong.Session do
       {:empty, _} ->
         %{state | agent_busy: false}
     end
+  end
+
+  defp maybe_sync_model_from_settings(%{model_sync_enabled: false} = state),
+    do: {state, %{changed: false, reason: :disabled}}
+
+  defp maybe_sync_model_from_settings(state) do
+    _ = Settings.reload(state.workspace)
+    desired_model = Settings.get_model() |> to_string() |> String.trim()
+    current_model = current_model_for_prompt(state)
+
+    cond do
+      desired_model == "" ->
+        {state, %{changed: false, reason: :missing}}
+
+      desired_model == current_model ->
+        {state, %{changed: false, reason: :unchanged, model: current_model}}
+
+      true ->
+        case ModelRegistry.resolve_registered_model(desired_model) do
+          {:ok, resolved} ->
+            llm_backend_fn = AgentLoop.build_llm_backend(ModelRegistry.apply_defaults(resolved.config))
+            thinking_level = Map.get(resolved.config, :thinking_level, "off") |> to_string()
+
+            new_metadata =
+              state.metadata
+              |> put_in(["session", "model"], resolved.short)
+              |> put_in(["session", "thinking", "level"], thinking_level)
+
+            new_state = %{state | llm_backend_fn: llm_backend_fn, metadata: new_metadata}
+            {new_state, %{changed: true, model: resolved.short, full_model: resolved.model}}
+
+          {:error, :unknown_provider} ->
+            Logger.warning("Session settings 模型无效，忽略热重载: #{inspect(desired_model)}")
+            {state, %{changed: false, reason: :invalid, requested: desired_model}}
+        end
+    end
+  end
+
+  defp current_model_for_prompt(state) do
+    get_in(state.metadata, ["session", "model"]) || @default_model
+  end
+
+  defp available_models_for_prompt do
+    ModelRegistry.available_models()
+    |> Enum.map(fn item -> "#{item.short}(#{item.model})" end)
   end
 
   defp payload_get(map, key), do: Events.payload_get(map, key)

--- a/lib/gong/settings.ex
+++ b/lib/gong/settings.ex
@@ -79,6 +79,42 @@ defmodule Gong.Settings do
     :ok
   end
 
+  @doc "获取当前模型设置"
+  @spec get_model() :: String.t()
+  def get_model do
+    get("model")
+  end
+
+  @doc """
+  持久化设置模型（原子写）。
+
+  返回归一化后的模型信息（短名 + 完整名）。
+  """
+  @spec set_model(String.t(), String.t()) ::
+          {:ok, %{short: String.t(), model: String.t()}}
+          | {:error, :unknown_provider | :persist_failed}
+  def set_model(workspace, model_name) when is_binary(workspace) and is_binary(model_name) do
+    if :ets.info(@table) == :undefined do
+      init(workspace)
+    end
+
+    case Gong.ModelRegistry.resolve_registered_model(model_name) do
+      {:ok, resolved} ->
+        :ets.insert(@table, {"model", resolved.short})
+
+        case persist(workspace) do
+          :ok ->
+            {:ok, %{short: resolved.short, model: resolved.model}}
+
+          {:error, _reason} ->
+            {:error, :persist_failed}
+        end
+
+      {:error, :unknown_provider} ->
+        {:error, :unknown_provider}
+    end
+  end
+
   @doc "列出所有设置"
   @spec list() :: map()
   def list do
@@ -164,6 +200,30 @@ defmodule Gong.Settings do
         _ ->
           :ok
       end
+    end
+  end
+
+  defp persist(workspace) do
+    dir = Path.join([workspace, ".gong"])
+    file = Path.join(dir, "settings.json")
+    tmp = file <> ".tmp"
+
+    with :ok <- File.mkdir_p(dir),
+         content <- list() |> Jason.encode!(pretty: true),
+         :ok <- File.write(tmp, content),
+         {:ok, fd} <- :file.open(String.to_charlist(tmp), [:read, :raw]),
+         :ok <- :file.sync(fd),
+         :ok <- :file.close(fd),
+         :ok <- File.rename(tmp, file) do
+      :ok
+    else
+      {:error, reason} ->
+        _ = File.rm(tmp)
+        {:error, reason}
+
+      reason ->
+        _ = File.rm(tmp)
+        {:error, reason}
     end
   end
 end

--- a/test/gong/cli/renderer_test.exs
+++ b/test/gong/cli/renderer_test.exs
@@ -156,6 +156,17 @@ defmodule Gong.CLI.RendererTest do
       output = capture_io(:stderr, fn -> Renderer.render(event) end)
       assert output =~ "未知错误"
     end
+
+    test "error.runtime 为 ReqLLM 结构体字符串时提取简洁 message" do
+      raw =
+        "%ReqLLM.Error.API.Request{reason: \"auth failed\", status: 401, response_body: %{\"message\" => \"token invalid\"}}"
+
+      event = make_event("error.runtime", %{message: raw})
+      output = capture_io(:stderr, fn -> Renderer.render(event) end)
+
+      assert output =~ "token invalid"
+      refute output =~ "ReqLLM.Error.API.Request"
+    end
   end
 
   describe "truncate/2" do

--- a/test/gong/llm_router_test.exs
+++ b/test/gong/llm_router_test.exs
@@ -315,4 +315,30 @@ defmodule Gong.LLMRouterTest do
       assert openai_resolved.receive_timeout == 30_000
     end
   end
+
+  describe "错误处理与预校验" do
+    test "缺少 API key 时请求前返回 unauthorized 友好错误" do
+      System.delete_env("NONEXISTENT_ROUTER_KEY")
+
+      model_config = %{
+        provider: "deepseek",
+        model_id: "deepseek-chat",
+        api_key_env: "NONEXISTENT_ROUTER_KEY"
+      }
+
+      assert {:error, error} = LLMRouter.stream_text(model_config, [%{role: :user, content: "hi"}], [])
+      assert error.code == :unauthorized
+      assert error.message =~ "缺少 NONEXISTENT_ROUTER_KEY"
+    end
+
+    test "humanize_error 提取 response_body.message 与状态码" do
+      error = %{
+        reason: "auth failed",
+        status: 401,
+        response_body: %{"message" => "token invalid"}
+      }
+
+      assert LLMRouter.humanize_error(error) == "token invalid (HTTP 401)"
+    end
+  end
 end

--- a/test/gong/model_registry_short_name_test.exs
+++ b/test/gong/model_registry_short_name_test.exs
@@ -61,4 +61,27 @@ defmodule Gong.ModelRegistryShortNameTest do
   test "未知短名返回错误" do
     assert {:error, :unknown_provider} = ModelRegistry.lookup_by_string("not-exists")
   end
+
+  test "resolve_registered_model 仅命中已注册模型，不做兜底构造" do
+    assert {:ok, resolved} = ModelRegistry.resolve_registered_model("k2p5")
+    assert resolved.short == "kimi"
+    assert resolved.model == "kimi:k2p5"
+
+    assert {:ok, resolved2} = ModelRegistry.resolve_registered_model("minimax:MiniMax-M2.5")
+    assert resolved2.short == "minimax"
+    assert resolved2.model == "minimax:MiniMax-M2.5"
+
+    assert {:error, :unknown_provider} = ModelRegistry.resolve_registered_model("unknown:model")
+  end
+
+  test "available_models 返回短名与完整名映射" do
+    available = ModelRegistry.available_models()
+    shorts = Enum.map(available, & &1.short)
+    models = Enum.map(available, & &1.model)
+
+    assert "kimi" in shorts
+    assert "minimax" in shorts
+    assert "glm" in shorts
+    assert "kimi:k2p5" in models
+  end
 end

--- a/test/gong/prompt_test.exs
+++ b/test/gong/prompt_test.exs
@@ -1,0 +1,18 @@
+defmodule Gong.PromptTest do
+  use ExUnit.Case, async: true
+
+  alias Gong.Prompt
+
+  test "full_system_prompt 注入当前模型与可用模型列表" do
+    prompt =
+      Prompt.full_system_prompt(
+        workspace: "/tmp/project",
+        current_model: "kimi",
+        available_models: ["kimi(kimi:k2p5)", "minimax(minimax:MiniMax-M2.5)"]
+      )
+
+    assert prompt =~ "当前模型：kimi"
+    assert prompt =~ "可用模型：kimi(kimi:k2p5), minimax(minimax:MiniMax-M2.5)"
+    assert prompt =~ "当前工作目录：/tmp/project"
+  end
+end

--- a/test/gong/session_model_sync_test.exs
+++ b/test/gong/session_model_sync_test.exs
@@ -1,0 +1,72 @@
+defmodule Gong.SessionModelSyncTest do
+  use ExUnit.Case, async: false
+
+  alias Gong.ModelRegistry
+  alias Gong.Session
+  alias Gong.Settings
+
+  setup do
+    workspace = Path.join(System.tmp_dir!(), "gong-session-sync-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(workspace)
+
+    ModelRegistry.init()
+
+    ModelRegistry.register(:minimax, %{
+      provider: "minimax",
+      model_id: "MiniMax-M2.5",
+      api_key_env: "MINIMAX_API_KEY"
+    })
+
+    ModelRegistry.register(:kimi, %{
+      provider: "kimi",
+      model_id: "k2p5",
+      api_key_env: "KIMI_API_KEY"
+    })
+
+    Settings.cleanup()
+    Settings.init(workspace)
+    {:ok, _} = Settings.set_model(workspace, "minimax")
+
+    {:ok, session} =
+      Session.start_link(
+        session_id: "session-model-sync",
+        model: "minimax",
+        workspace: workspace,
+        model_sync: true
+      )
+
+    on_exit(fn ->
+      if Process.alive?(session), do: Session.close(session)
+      Settings.cleanup()
+      ModelRegistry.cleanup()
+      File.rm_rf!(workspace)
+    end)
+
+    {:ok, workspace: workspace, session: session}
+  end
+
+  test "sync_model 在 settings 变更后更新 session metadata", %{workspace: workspace, session: session} do
+    assert {:ok, %{changed: false}} = Session.sync_model(session)
+
+    assert {:ok, %{short: "kimi"}} = Settings.set_model(workspace, "k2p5")
+    assert {:ok, %{changed: true, model: "kimi"}} = Session.sync_model(session)
+
+    assert {:ok, metadata} = Session.metadata(session)
+    assert get_in(metadata, ["session", "model"]) == "kimi"
+  end
+
+  test "settings 写入非法模型时，sync_model 忽略变更并保持当前模型", %{
+    workspace: workspace,
+    session: session
+  } do
+    settings_file = Path.join([workspace, ".gong", "settings.json"])
+    File.mkdir_p!(Path.dirname(settings_file))
+    File.write!(settings_file, ~s({"model":"unknown-model"}))
+
+    assert {:ok, %{changed: false, reason: :invalid, requested: "unknown-model"}} =
+             Session.sync_model(session)
+
+    assert {:ok, metadata} = Session.metadata(session)
+    assert get_in(metadata, ["session", "model"]) == "minimax"
+  end
+end

--- a/test/gong/settings_test.exs
+++ b/test/gong/settings_test.exs
@@ -1,0 +1,57 @@
+defmodule Gong.SettingsTest do
+  use ExUnit.Case, async: false
+
+  alias Gong.ModelRegistry
+  alias Gong.Settings
+
+  setup do
+    workspace = Path.join(System.tmp_dir!(), "gong-settings-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(workspace)
+
+    ModelRegistry.init()
+
+    ModelRegistry.register(:minimax, %{
+      provider: "minimax",
+      model_id: "MiniMax-M2.5",
+      api_key_env: "MINIMAX_API_KEY"
+    })
+
+    ModelRegistry.register(:kimi, %{
+      provider: "kimi",
+      model_id: "k2p5",
+      api_key_env: "KIMI_API_KEY"
+    })
+
+    Settings.cleanup()
+    Settings.init(workspace)
+
+    on_exit(fn ->
+      Settings.cleanup()
+      ModelRegistry.cleanup()
+      File.rm_rf!(workspace)
+    end)
+
+    {:ok, workspace: workspace}
+  end
+
+  test "set_model 原子写 settings.json 并更新 ETS", %{workspace: workspace} do
+    assert {:ok, %{short: "kimi", model: "kimi:k2p5"}} = Settings.set_model(workspace, "k2p5")
+    assert Settings.get_model() == "kimi"
+
+    settings_file = Path.join([workspace, ".gong", "settings.json"])
+    assert File.exists?(settings_file)
+    refute File.exists?(settings_file <> ".tmp")
+
+    {:ok, content} = File.read(settings_file)
+    {:ok, settings_map} = Jason.decode(content)
+    assert settings_map["model"] == "kimi"
+  end
+
+  test "set_model 遇到未知模型返回错误，不修改当前模型", %{workspace: workspace} do
+    assert {:ok, %{short: "minimax", model: "minimax:MiniMax-M2.5"}} =
+             Settings.set_model(workspace, "minimax")
+
+    assert {:error, :unknown_provider} = Settings.set_model(workspace, "not-exists")
+    assert Settings.get_model() == "minimax"
+  end
+end


### PR DESCRIPTION
Closes #95

## Summary
- 新增严格模型解析能力：`ModelRegistry.resolve_registered_model/1` 与 `available_models/0`，用于命令校验和模型列表展示。
- 新增设置层模型持久化：`Settings.set_model/2`，采用 `settings.json.tmp -> fsync -> rename` 原子写。
- Session 增强模型同步：新增 `Session.sync_model/1`，并在每轮请求前自动从 settings 同步模型（仅在 `model_sync: true` 时启用）。
- Chat 命令增强：新增 `/models` 与 `/model <name>`，支持会话内立即切换模型并持久化。
- System Prompt 增强：注入当前模型与可用模型列表信息，提升 agent 对模型上下文可见性。

## Test plan
- `mix test test/gong/model_registry_short_name_test.exs test/gong/settings_test.exs test/gong/session_model_sync_test.exs test/gong/prompt_test.exs`
- `mix test test/gong/session_test.exs`
